### PR TITLE
Disallow setting deadline at night

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4902,6 +4902,10 @@ async def on_message(message):
                     await safe_send(message.author, "You don't have permission to set deadlines.")
                     return
 
+                if not game.isDay:
+                    await safe_send(message.author, "It's not day right now.")
+                    return
+
                 deadline = parse_deadline(argument)
 
                 if deadline is None:


### PR DESCRIPTION
While doing some testing to make sure things still worked after moving to new directory I accidentally set deadline during first night at got this exception

> [2024-07-05 09:21:18] [ERROR   ] discord.client: Ignoring exception in on_message
Traceback (most recent call last):
  File "/Users/dlorant/IdeaProjects/botc-bot/venv/lib/python3.9/site-packages/discord/client.py", line 441, in _run_event
    await coro(*args, **kwargs)
  File "/Users/dlorant/IdeaProjects/botc-bot/bot.py", line 4911, in on_message
    if len(game.days[-1].deadlineMessages) > 0:
IndexError: list index out of range


This seems like the best fix since nominations at night aren't (currently) a thing in BotC