### PR TITLE
Feature/channel awareness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ token.txt
 config.py
 discord.log
 *.pckl
+*.json
 +class_generator.py
 .DS_Store
 testing.py

--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@ A WIP bot for playing Blood on the Clocktower.
 ## config.py
 You'll want a `config.py` file in the root directory with the following variables declared
 ```
-channelid = 1028299479348154418
-whisperchannelid = 1251894128602779728
-serverid = 721446589750706266
+serverid = 721446589750706266 # Guild ID for Game Server
+GAME_CATEGORY_ID = 1202456091057725550  # Category for in play player channels and game channels
+HANDS_CHANNEL_ID = 1260773800400912545  # Hands ST Channel
+OBSERVER_CHANNEL_ID = 1260773624101605466 # Observer Channel
+INFO_CHANNEL_ID = 1260775601413816320  # Info Channel
+whisperchannelid = 1251894128602779728 # Channel for player whispers
+channelid = 1028299479348154418 # Town Square
+OUT_OF_PLAY_CATEGORY_ID = 1260776733674704997  # Category for out of play player channels
+
+# Role Names
 playerName = "player"
 travelerName = "traveler"
 ghostName = "ghost"

--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@ A WIP bot for playing Blood on the Clocktower.
 ## config.py
 You'll want a `config.py` file in the root directory with the following variables declared
 ```
-serverid = 721446589750706266 # Guild ID for Game Server
+SERVER_ID = 721446589750706266 # Guild ID for Game Server
 GAME_CATEGORY_ID = 1202456091057725550  # Category for in play player channels and game channels
 HANDS_CHANNEL_ID = 1260773800400912545  # Hands ST Channel
 OBSERVER_CHANNEL_ID = 1260773624101605466 # Observer Channel
 INFO_CHANNEL_ID = 1260775601413816320  # Info Channel
-whisperchannelid = 1251894128602779728 # Channel for player whispers
-channelid = 1028299479348154418 # Town Square
+WHISPER_CHANNEL_ID = 1251894128602779728 # Channel for player whispers
+TOWN_SQUARE_CHANNEL_ID = 1028299479348154418 # Town Square
 OUT_OF_PLAY_CATEGORY_ID = 1260776733674704997  # Category for out of play player channels
 
 # Role Names
-playerName = "player"
-travelerName = "traveler"
-ghostName = "ghost"
-deadVoteName = "deadVote"
-gamemasterName = "gamemaster"
-inactiveName = "inactive"
-observerName = "observer"
+PLAYER_ROLE = "player"
+TRAVELER_ROLE = "traveler"
+GHOST_ROLE = "ghost"
+DEAD_VOTE_ROLE = "deadVote"
+STORYTELLER_ROLE = "gamemaster"
+INACTIVE_ROLE = "inactive"
+OBSERVER_ROLE = "observer"
 
 prefixes = (',', '@')
 ```

--- a/bot.py
+++ b/bot.py
@@ -3725,13 +3725,13 @@ async def on_ready():
     game = NULL_GAME
     observerRole = None
 
-    server = client.get_guild(serverid)
+    server = client.get_guild(SERVER_ID)
     game_category = client.get_channel(GAME_CATEGORY_ID)
     hands_channel = client.get_channel(HANDS_CHANNEL_ID)
     observer_channel = client.get_channel(OBSERVER_CHANNEL_ID)
     info_channel = client.get_channel(INFO_CHANNEL_ID)
-    whisper_channel = client.get_channel(whisperchannelid)
-    channel = client.get_channel(channelid)
+    whisper_channel = client.get_channel(WHISPER_CHANNEL_ID)
+    channel = client.get_channel(TOWN_SQUARE_CHANNEL_ID)
     out_of_play_category = client.get_channel(OUT_OF_PLAY_CATEGORY_ID)
     logger.info(logger.info(
         f"server: {server.name}, "
@@ -3745,19 +3745,19 @@ async def on_ready():
     ))
 
     for role in server.roles:
-        if role.name == playerName:
+        if role.name == PLAYER_ROLE:
             playerRole = role
-        elif role.name == travelerName:
+        elif role.name == TRAVELER_ROLE:
             travelerRole = role
-        elif role.name == ghostName:
+        elif role.name == GHOST_ROLE:
             ghostRole = role
-        elif role.name == deadVoteName:
+        elif role.name == DEAD_VOTE_ROLE:
             deadVoteRole = role
-        elif role.name == gamemasterName:
+        elif role.name == STORYTELLER_ROLE:
             gamemasterRole = role
-        elif role.name == inactiveName:
+        elif role.name == INACTIVE_ROLE:
             inactiveRole = role
-        elif role.name == observerName:
+        elif role.name == OBSERVER_ROLE:
             observerRole = role
 
     if os.path.isfile("current_game.pckl"):

--- a/bot.py
+++ b/bot.py
@@ -3721,14 +3721,28 @@ async def safe_send(target: discord.abc.Messageable, msg: str):
 async def on_ready():
     # On startup
 
-    global server, channel, whisper_channel, playerRole, travelerRole, ghostRole, deadVoteRole, gamemasterRole, inactiveRole, observerRole, game
+    global server, game_category, hands_channel, observer_channel, info_channel, whisper_channel, channel, out_of_play_category, playerRole, travelerRole, ghostRole, deadVoteRole, gamemasterRole, inactiveRole, observerRole, game
     game = NULL_GAME
     observerRole = None
 
     server = client.get_guild(serverid)
+    game_category = client.get_channel(GAME_CATEGORY_ID)
+    hands_channel = client.get_channel(HANDS_CHANNEL_ID)
+    observer_channel = client.get_channel(OBSERVER_CHANNEL_ID)
+    info_channel = client.get_channel(INFO_CHANNEL_ID)
+    whisper_channel = client.get_channel(whisperchannelid)
     channel = client.get_channel(channelid)
-    whisper_channel = client.get_channel(whisperchannelid) if whisperchannelid else None
-    logger.info("channel: " + channel.name + ", whisper_channel: " + whisper_channel.name)
+    out_of_play_category = client.get_channel(OUT_OF_PLAY_CATEGORY_ID)
+    logger.info(logger.info(
+        f"server: {server.name}, "
+        f"game_category: {game_category.name}, "
+        f"hands_channel: {hands_channel.name}, "
+        f"observer_channel: {observer_channel.name}, "
+        f"info_channel: {info_channel.name}, "
+        f"whisper_channel: {whisper_channel.name}, "
+        f"townsquare_channel: {channel.name}, "
+        f"out_of_play_category: {out_of_play_category.name}, "
+    ))
 
     for role in server.roles:
         if role.name == playerName:

--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,7 @@ import dill
 import discord
 
 from config import *
+from model.settings.game_settings import GameSettings
 from time_utils import parse_deadline
 
 print("Starting bot...")
@@ -929,6 +930,7 @@ class Player:
         self.messageHistory = []
         self.riot_nominee = False
         self.last_active = datetime.now().timestamp()
+        self.st_channel = GameSettings.load_from_file().get_st_channel(user.id)
 
         if inactiveRole in self.user.roles:
             self.isInactive = True

--- a/model/channels/__init__.py
+++ b/model/channels/__init__.py
@@ -1,0 +1,3 @@
+from .channel_manager import ChannelManager
+
+__all__ = ['ChannelManager']

--- a/model/channels/channel_manager.py
+++ b/model/channels/channel_manager.py
@@ -1,0 +1,73 @@
+import discord
+import logging
+
+logger = logging.getLogger('discord')
+
+
+class ChannelManager:
+    """Encapsulates logic for managing Discord Channels."""
+
+    _client: discord.client.Client
+
+    def __init__(self, client: discord.client.Client):
+        self._client = client
+
+    async def toggle_ghost(self, channel_id: int):
+        """
+        Toggles '👤' and '👻' in the channel name for the given channel ID.
+
+        Parameters:
+        - channel_id: The ID of the channel to update.
+        """
+        # Retrieve the channel object using the channel ID
+        channel = self._client.get_channel(channel_id)
+        if channel is None:
+            logger.info(f"Channel with ID {channel_id} not found.")
+            return
+
+        if channel is not None:
+            # Check and replace '👤' with '👻' or vice versa
+            if "👤" in channel.name:
+                new_name = channel.name.replace("👤", "👻")
+            elif "👻" in channel.name:
+                new_name = channel.name.replace("👻", "👤")
+            else:
+                logger.info("No emoji found to toggle.")
+                return
+
+            # Update the channel name
+            await channel.edit(name=new_name)
+
+    async def move_channel_to_category(self, channel_id: int, category_id: int) -> bool:
+        """
+        Moves a channel to a specified category.
+
+        Parameters:
+        - channel_id: The ID of the channel to move.
+        - category_id: The ID of the category to move the channel into.
+        """
+        # Retrieve the channel and category objects using their IDs
+        channel: discord.TextChannel = self._client.get_channel(channel_id)
+        new_category: discord.CategoryChannel = self._client.get_channel(category_id)
+
+        # Check if both the channel and category exist
+        if channel is None or new_category is None:
+            logger.info(f"Either channel with ID {channel_id} or category with ID {category_id} was not found.")
+            return False
+
+        if not isinstance(channel, discord.TextChannel):
+            logger.info(f"Channel with ID {channel_id} is not a text channel.")
+            return False
+
+        if not isinstance(new_category, discord.CategoryChannel):
+            logger.info(f"Category with ID {category_id} is not a category channel.")
+            return False
+
+        # Move the channel to the category
+        try:
+            await channel.edit(category=new_category)
+            logger.info(f"Channel {channel.name} has been moved to category {new_category.name}.")
+            return True
+        except discord.HTTPException as e:
+            logger.warning(f"An error occurred while moving channel {channel.name} to category {new_category.name}: {e}.")
+            return False

--- a/model/channels/test_channel_manager.py
+++ b/model/channels/test_channel_manager.py
@@ -1,0 +1,96 @@
+import unittest
+from unittest.mock import MagicMock, AsyncMock
+
+import discord
+
+from model.channels.channel_manager import ChannelManager
+
+
+class TestChannelManager(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.mock_client = MagicMock(spec=discord.Client)
+        self.mock_channel = MagicMock(spec=discord.TextChannel)
+        self.mock_category = MagicMock(spec=discord.CategoryChannel)
+        self.channel_manager = ChannelManager(self.mock_client)
+
+    # ==============================
+    # Tests for toggle_ghost
+    # ==============================
+    async def test_toggle_ghost_from_person_to_ghost(self):
+        mock_channel = MagicMock()
+        mock_channel.name = "Test Channel 👤"
+        mock_channel.edit = AsyncMock()
+        self.mock_client.get_channel.return_value = mock_channel
+
+        await self.channel_manager.toggle_ghost(123)
+        mock_channel.edit.assert_called_once_with(name="Test Channel 👻")
+
+    async def test_toggle_ghost_from_ghost_to_person(self):
+        mock_channel = MagicMock()
+        mock_channel.name = "Test Channel 👻"
+        mock_channel.edit = AsyncMock()
+        self.mock_client.get_channel.return_value = mock_channel
+
+        await self.channel_manager.toggle_ghost(123)
+        mock_channel.edit.assert_called_once_with(name="Test Channel 👤")
+
+    async def test_toggle_ghost_no_emoji_found(self):
+        mock_channel = MagicMock()
+        mock_channel.name = "Test Channel"
+        mock_channel.edit = AsyncMock()
+        self.mock_client.get_channel.return_value = mock_channel
+
+        await self.channel_manager.toggle_ghost(123)
+        mock_channel.edit.assert_not_called()
+
+    async def test_toggle_ghost_channel_not_found(self):
+        self.mock_client.get_channel.return_value = None
+
+        with self.assertLogs(level='INFO') as log:
+            await self.channel_manager.toggle_ghost(123)
+            self.assertIn("Channel with ID 123 not found.", log.output[0])
+
+    # ==================================
+    # Tests for move_channel_to_category
+    # ==================================
+
+    async def test_move_channel_to_category_success(self):
+        self.mock_client.get_channel.side_effect = lambda x: self.mock_channel if x == 123 else self.mock_category
+        result = await self.channel_manager.move_channel_to_category(123, 456)
+        self.assertTrue(result)
+        self.mock_channel.edit.assert_called_once_with(category=self.mock_category)
+
+    async def test_move_channel_to_category_channel_not_found(self):
+        self.mock_client.get_channel.side_effect = lambda x: None if x == 123 else self.mock_category
+        result = await self.channel_manager.move_channel_to_category(123, 456)
+        self.assertFalse(result)
+
+    async def test_move_channel_to_category_category_not_found(self):
+        self.mock_client.get_channel.side_effect = lambda x: self.mock_channel if x == 123 else None
+        result = await self.channel_manager.move_channel_to_category(123, 456)
+        self.assertFalse(result)
+
+    async def test_move_channel_to_category_channel_not_text_channel(self):
+        non_text_channel = MagicMock(spec=discord.VoiceChannel)  # Mock object not of type discord.TextChannel
+        self.mock_client.get_channel.side_effect = lambda x: non_text_channel if x == 123 else self.mock_category
+        result = await self.channel_manager.move_channel_to_category(123, 456)
+        self.assertFalse(result)
+
+    async def test_move_channel_to_category_category_not_category_channel(self):
+        non_category_channel = MagicMock(spec=discord.VoiceChannel)  # Mock object not of type discord.CategoryChannel
+        self.mock_client.get_channel.side_effect = lambda x: self.mock_channel if x == 123 else non_category_channel
+        result = await self.channel_manager.move_channel_to_category(123, 456)
+        self.assertFalse(result)
+
+    async def test_move_channel_to_category_http_exception(self):
+        self.mock_client.get_channel.side_effect = lambda x: self.mock_channel if x == 123 else self.mock_category
+        self.mock_channel.edit.side_effect = discord.HTTPException(MagicMock(), MagicMock())
+        with self.assertLogs(level='INFO') as log:
+            result = await self.channel_manager.move_channel_to_category(123, 456)
+            self.assertFalse(result)
+            self.assertIn("An error occurred while moving channel", log.output[0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/model/settings/__init__.py
+++ b/model/settings/__init__.py
@@ -1,0 +1,3 @@
+from .game_settings import GameSettings
+
+__all__ = ['GameSettings']

--- a/model/settings/game_settings.py
+++ b/model/settings/game_settings.py
@@ -1,0 +1,68 @@
+import json
+
+_SETTINGS_FILENAME = 'settings.json'
+
+
+class GameSettings:
+    _settings: dict[int, dict[str, any]]
+    """Class to store and manage game settings.  """
+
+    def __init__(self):
+        self._settings = {}
+
+    # ==============================
+    # ST Room Settings
+    # ==============================
+    def set_st_channel(self, player_id: int, channel_id: int):
+        """Set the channel ID for the ST room for a specific player."""
+        self._update_settings(player_id, {"st_channel": channel_id})
+
+    def get_st_channel(self, player_id: int):
+        """Get the channel ID for the ST room for a specific player."""
+        return self._get_settings(player_id, "st_channel")
+
+    def clear_st_channel(self, player_id: int):
+        """Clear the channel ID for the ST room for a specific player."""
+        self._clear_setting(player_id, "st_channel")
+
+    # ==============================
+    # Generic settings methods
+    # ==============================
+
+    def _update_settings(self, player_id: int, dict_to_merge: dict):
+        """Update settings for a specific player, merging with existing settings if present."""
+        if player_id in self._settings:
+            # Merge existing settings with new settings
+            self._settings[player_id].update(dict_to_merge)
+        else:
+            # Add new settings for the player
+            self._settings[player_id] = dict_to_merge
+
+    def _get_settings(self, player_id: int, setting_name: str):
+        """Get a specific setting for a player."""
+        return self._settings.get(player_id, {}).get(setting_name)
+
+    def _clear_setting(self, player_id: int, setting_name: str):
+        """Remove a specific setting for a player."""
+        if player_id in self._settings:
+            self._settings[player_id].pop(setting_name, None)
+
+    # ==============================
+    # Serialization/Deserialization
+    # ==============================
+
+    def save_to_file(self):
+        """Save settings to a JSON file."""
+        with open(_SETTINGS_FILENAME, 'w') as f:
+            json.dump(self._settings, f)
+
+    @staticmethod
+    def load_from_file():
+        """Load settings from a JSON file and return a new GameSettings object."""
+        with open(_SETTINGS_FILENAME, 'r') as f:
+            settings_data = json.load(f)
+        # Convert keys from string to int
+        normalized_data = {int(k): v for k, v in settings_data.items()}
+        new_game_settings = GameSettings()
+        new_game_settings._settings = normalized_data
+        return new_game_settings

--- a/model/settings/game_settings.py
+++ b/model/settings/game_settings.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 _SETTINGS_FILENAME = 'settings.json'
 
@@ -59,8 +60,16 @@ class GameSettings:
     @staticmethod
     def load_from_file():
         """Load settings from a JSON file and return a new GameSettings object."""
+        # Check if the file exists
+        if not os.path.exists(_SETTINGS_FILENAME):
+            # Create the file with default settings
+            with open(_SETTINGS_FILENAME, 'w') as f:
+                json.dump({}, f)
+
+        # Proceed with loading the settings
         with open(_SETTINGS_FILENAME, 'r') as f:
             settings_data = json.load(f)
+
         # Convert keys from string to int
         normalized_data = {int(k): v for k, v in settings_data.items()}
         new_game_settings = GameSettings()

--- a/model/settings/test_game_settings.py
+++ b/model/settings/test_game_settings.py
@@ -1,0 +1,54 @@
+import unittest
+from model.settings.game_settings import GameSettings
+import model.settings.game_settings
+import os
+
+
+class TestGameSettings(unittest.TestCase):
+
+    def setUp(self):
+        self.original_filename = model.settings.game_settings._SETTINGS_FILENAME
+        model.settings.game_settings._SETTINGS_FILENAME = 'test_settings.json'
+        self.game_settings = GameSettings()
+        self.test_filename = model.settings.game_settings._SETTINGS_FILENAME
+
+    def tearDown(self):
+        if os.path.exists(self.test_filename):
+            os.remove(self.test_filename)
+        model.settings.game_settings._SETTINGS_FILENAME = self.original_filename
+
+    def test_init(self):
+        self.assertDictEqual(self.game_settings._settings, {})
+
+    def test_set_st_channel(self):
+        self.game_settings.set_st_channel(1, 12345)
+        self.assertEqual(self.game_settings._settings[1], {"st_channel": 12345})
+
+    def test_get_st_channel(self):
+        self.game_settings._settings[1] = {"st_channel": 12345}
+        self.assertEqual(self.game_settings.get_st_channel(1), 12345)
+
+    def test_clear_st_channel(self):
+        self.game_settings._settings[1] = {"st_channel": 12345}
+        self.game_settings.clear_st_channel(1)
+        self.assertNotIn("st_channel", self.game_settings._settings[1])
+
+    def test_update_settings_update_setting(self):
+        self.game_settings._update_settings(1, {"volume": 50})
+        self.game_settings._update_settings(1, {"volume": 100})
+        self.assertEqual(self.game_settings._settings[1], {"volume": 100})
+
+    def test_update_settings_additional_setting(self):
+        self.game_settings._update_settings(1, {"volume": 50})
+        self.game_settings._update_settings(1, {"surface_area": 25})
+        self.assertEqual(self.game_settings._settings[1], {"volume": 50, "surface_area": 25})
+
+    def test_save_and_load(self):
+        self.game_settings.set_st_channel(1, 12345)
+        self.game_settings.save_to_file()
+        loaded_settings = GameSettings.load_from_file()
+        self.assertEqual(self.game_settings._settings, loaded_settings._settings)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/model/settings/test_game_settings.py
+++ b/model/settings/test_game_settings.py
@@ -28,6 +28,9 @@ class TestGameSettings(unittest.TestCase):
         self.game_settings._settings[1] = {"st_channel": 12345}
         self.assertEqual(self.game_settings.get_st_channel(1), 12345)
 
+    def test_get_unset_st_channel(self):
+        self.assertIsNone(self.game_settings.get_st_channel(1))
+
     def test_clear_st_channel(self):
         self.game_settings._settings[1] = {"st_channel": 12345}
         self.game_settings.clear_st_channel(1)
@@ -42,6 +45,11 @@ class TestGameSettings(unittest.TestCase):
         self.game_settings._update_settings(1, {"volume": 50})
         self.game_settings._update_settings(1, {"surface_area": 25})
         self.assertEqual(self.game_settings._settings[1], {"volume": 50, "surface_area": 25})
+
+    def test_load_no_file(self):
+        loaded_settings = GameSettings.load_from_file()
+        self.assertTrue(os.path.exists(self.test_filename))
+        self.assertDictEqual(loaded_settings._settings, {})
 
     def test_save_and_load(self):
         self.game_settings.set_st_channel(1, 12345)


### PR DESCRIPTION
First couple of steps towards channel awareness in the bot.  Right now it simply provides awareness of the global game channels and relevant channel categories via the config file.

Future changes will include a per-game# config object (that will be pickled and not deleted between games) that will contain player-ST channel IDs.

Some planned features that require this functionality include:
- Automatic rearrangement of channels into grim order, including moving out of game channels to the icebox category
- Automatically adding ghost icon for dead players
- Automatic checkin (and ability choice) requests at start of night
- Notification to STs when all players have checked in
- And more!