### PR TITLE
treat the game categories and extra channels as Optional

### DIFF
--- a/bot_impl.py
+++ b/bot_impl.py
@@ -3716,13 +3716,13 @@ async def on_ready():
     global_vars.out_of_play_category = client.get_channel(OUT_OF_PLAY_CATEGORY_ID)
     logger.info(logger.info(
         f"server: {global_vars.server.name}, "
-        f"game_category: {global_vars.game_category.name}, "
-        f"hands_channel: {global_vars.hands_channel.name}, "
-        f"observer_channel: {global_vars.observer_channel.name}, "
-        f"info_channel: {global_vars.info_channel.name}, "
-        f"whisper_channel: {global_vars.whisper_channel.name}, "
+        f"game_category: {global_vars.game_category.name if global_vars.game_category else None}, "
+        f"hands_channel: {global_vars.hands_channel.name if global_vars.hands_channel else None}, "
+        f"observer_channel: {global_vars.observer_channel.name if global_vars.observer_channel else None}, "
+        f"info_channel: {global_vars.info_channel.name if global_vars.info_channel else None}, "
+        f"whisper_channel: {global_vars.whisper_channel.name if global_vars.whisper_channel else None}, "
         f"townsquare_channel: {global_vars.channel.name}, "
-        f"out_of_play_category: {global_vars.out_of_play_category.name}, "
+        f"out_of_play_category: {global_vars.out_of_play_category.name if global_vars.out_of_play_category else None}, "
     ))
 
     for role in global_vars.server.roles:


### PR DESCRIPTION
This will make it so the bot will start with just the server and the main channel if that's all you have.  Still remaining is to be able to not need the config.py constants for all the categories and channels a server doesn't have for the bot to start up.  could use try catches on each read... seemed too much though