### PR TITLE
Remove observer role from players at the start of a new game

### DIFF
--- a/bot_impl.py
+++ b/bot_impl.py
@@ -4092,6 +4092,8 @@ async def on_message(message):
                 for index, user in enumerate(users):
                     if global_vars.gamemaster_role in user.roles:
                         await user.remove_roles(global_vars.gamemaster_role)
+                    if global_vars.observer_role in user.roles:
+                        await user.remove_roles(global_vars.observer_role)
                     await user.add_roles(global_vars.player_role)
                     if issubclass(characters[index], Traveler):
                         await user.add_roles(global_vars.traveler_role)


### PR DESCRIPTION
While going through and updating game start logic I figured this should be added.  Like the ST tag it's probably later than we want to be removing since hands discussion happen before game starts, but still seems better to have then not have this.