### PR TITLE
Added a check for global nickname when searching for clarification of player names. 

### DIFF
--- a/bot_impl.py
+++ b/bot_impl.py
@@ -3411,7 +3411,9 @@ async def generate_possibilities(text, people):
     possibilities = []
     for person in people:
         if (
-            person.nick is not None and text.lower() in person.nick.lower()
+                person.nick is not None and text.lower() in person.nick.lower()
+        ) or (
+                person.global_name is not None and text.lower() in person.global_name.lower()
         ) or text.lower() in person.name.lower():
             possibilities.append(person)
     return possibilities


### PR DESCRIPTION
 For new users coming to 5ofSwords they likely have global nicknames rather than a per-server nickname these days.
 
 This came up when adding Becca to my server for testing, the bot could not find her as "Becca" without this change.