### PR TITLE
Extract `makealias` and enhance functionality (list and remove aliases, and prevent overwriting base commands)

### DIFF
--- a/bot_impl.py
+++ b/bot_impl.py
@@ -2999,28 +2999,6 @@ async def on_message(message):
                 await message_utils.safe_send(message.author, message_text)
                 return
 
-            # Create custom alias
-            elif command == "makealias":
-
-                argument = argument.split(" ")
-                if len(argument) != 2:
-                    await message_utils.safe_send(message.author,
-                                                  "makealias takes exactly two arguments: @makealias <alias> <command>")
-                    return
-
-                global_settings: GlobalSettings = GlobalSettings.load()
-                alias_term = argument[0]
-                command_term = argument[1]
-                if "makealias" == alias_term:
-                    await message_utils.safe_send(message.author, "Cannot alias the makealias command.")
-                    return
-                global_settings.set_alias(message.author.id, alias_term, command_term)
-                global_settings.save()
-                await message_utils.safe_send(message.author,
-                                              "Successfully created alias {} for command {}.".format(alias_term,
-                                                                                                     command_term))
-                return
-
             # Hand up
             elif command == "handup" or command == "handdown":
                 player = await get_player(message.author)

--- a/commands/help_commands.py
+++ b/commands/help_commands.py
@@ -196,7 +196,6 @@ class HelpGenerator:
                 HardcodedCommand("cancelprevote", "cancels an existing prevote"),
                 HardcodedCommand("defaultvote [vote=no] [time=60]",
                                  "will always vote vote in time minutes. if no arguments given, deletes existing defaults."),
-                HardcodedCommand("makealias <alias> <command>", "creates an alias for a command"),
                 HardcodedCommand("clear", "returns whitespace"),
                 HardcodedCommand("cannominate", "lists players who are yet to nominate or skip"),
                 HardcodedCommand("canbenominated", "lists players who are yet to be nominated"),

--- a/commands/loader.py
+++ b/commands/loader.py
@@ -7,6 +7,7 @@ def load_all_commands():
     command_modules = [
         "commands.debug_commands",
         "commands.help_commands",
+        "commands.utility_commands",
     ]
 
     for module_name in command_modules:

--- a/commands/utility_commands.py
+++ b/commands/utility_commands.py
@@ -1,0 +1,70 @@
+import discord
+
+from commands.command_enums import HelpSection, UserType
+from commands.registry import registry, CommandArgument
+from model.settings import GlobalSettings
+from utils import message_utils
+
+
+@registry.command(
+    name="makealias",
+    description="Creates, removes, or lists aliases for commands (per-user).",
+    help_sections=[HelpSection.MISC, HelpSection.PLAYER],
+    user_types=[UserType.STORYTELLER, UserType.PLAYER, UserType.OBSERVER, UserType.NONE],
+    arguments=[CommandArgument("alias", optional=True), CommandArgument("command", optional=True)]
+)
+async def makealias_command(message: discord.Message, argument: str):
+    """
+    Creates, removes, or lists aliases for commands (per-user).
+    Usage:
+        - No arguments: List all aliases for the user.
+        - One argument: Remove the alias for that user if it exists.
+        - Two arguments: Create a per-user alias.
+    """
+    args = argument.split() if argument.strip() else []
+    global_settings: GlobalSettings = GlobalSettings.load()
+    user_id = message.author.id
+
+    # If no arguments are provided, list all aliases for the user.
+    if not args:
+        aliases = global_settings.get_aliases(user_id)
+        if aliases:
+            alias_list = "\n".join([f"**{alias}** → {command}" for alias, command in sorted(aliases.items())])
+            await message_utils.safe_send(message.author, f"Your aliases:\n{alias_list}")
+        else:
+            await message_utils.safe_send(message.author, "You have no aliases set.")
+        return
+
+    # If one argument is provided, remove the alias if it exists.
+    if len(args) == 1:
+        alias_term = args[0]
+        if global_settings.get_alias(user_id, alias_term):
+            global_settings.clear_alias(user_id, alias_term)
+            global_settings.save()
+            await message_utils.safe_send(message.author, f"Successfully removed alias {alias_term}.")
+        else:
+            await message_utils.safe_send(message.author, f"No alias named {alias_term} exists.")
+        return
+
+    # If two arguments are provided, create a new alias.
+    if len(args) == 2:
+        alias_term, command_term = args
+        if alias_term in registry.get_all_commands():
+            await message_utils.safe_send(
+                message.author,
+                f"Cannot alias the command '{alias_term}' as it is a registered command."
+            )
+            return
+        global_settings.set_alias(user_id, alias_term, command_term)
+        global_settings.save()
+        await message_utils.safe_send(
+            message.author,
+            f"Successfully created alias {alias_term} for command {command_term}."
+        )
+        return
+
+    # If there are too many arguments, send an error message.
+    await message_utils.safe_send(
+        message.author,
+        f"makealias takes at most two arguments. You provided {len(args)}: {args}"
+    )

--- a/model/settings/global_settings.py
+++ b/model/settings/global_settings.py
@@ -37,6 +37,17 @@ class GlobalSettings:
         self._settings.update_settings(player_id, {'aliases': current_aliases})
         return self
 
+    def clear_alias(self, player_id: int, alias: str) -> GlobalSettings:
+        """Clear an alias for a player."""
+        # Retrieve current aliases or initialize an empty dictionary if none exist
+        current_aliases = self._settings.get_settings(player_id, "aliases") or {}
+        # Remove the specified alias if it exists
+        if alias in current_aliases:
+            del current_aliases[alias]
+            # Update the player's settings with the modified aliases dictionary
+            self._settings.update_settings(player_id, {'aliases': current_aliases})
+        return self
+
     # ==============================
     # Default Votes
     # ==============================

--- a/tests/commands/test_settings_functionality.py
+++ b/tests/commands/test_settings_functionality.py
@@ -209,3 +209,20 @@ async def test_global_settings_set_alias():
     mock_base_settings.get_settings.assert_called_once_with(1, "aliases")
     mock_base_settings.update_settings.assert_called_once_with(1, {
         'aliases': {"existing": "command", "test": "new_command"}})
+
+
+@pytest.mark.asyncio
+async def test_global_settings_clear_alias():
+    """Test clearing alias in global settings."""
+    # Create mock settings
+    mock_base_settings = MagicMock()
+    mock_base_settings.get_settings.return_value = {"existing": "command", "test": "to_remove"}
+    settings = GlobalSettings(mock_base_settings)
+
+    # Set alias
+    settings.clear_alias(1, "test")
+
+    # Verify get_settings and update_settings were called correctly
+    mock_base_settings.get_settings.assert_called_once_with(1, "aliases")
+    mock_base_settings.update_settings.assert_called_once_with(1, {
+        'aliases': {"existing": "command"}})

--- a/tests/discord/test_on_message.py
+++ b/tests/discord/test_on_message.py
@@ -565,48 +565,6 @@ async def test_whispers_command(mock_discord_setup, setup_test_game):
 
 
 @pytest.mark.asyncio
-async def test_makealias_command(mock_discord_setup):
-    """Test making a command alias."""
-    # Create a direct message channel for Alice
-    alice_dm_channel = MockChannel(401, "dm-alice")
-    alice_dm_channel.guild = None  # Simulate DM
-
-    # Setup mock server for role check (needed for many command handlers)
-    mock_server = MagicMock()
-    mock_member = MagicMock()
-    mock_member.roles = []  # Not a storyteller
-    mock_server.get_member.return_value = mock_member
-    global_vars.server = mock_server
-
-    # Create a makealias message from Alice
-    alice_message = MockMessage(
-        id=16,
-        content="@makealias v vote",  # Make 'v' an alias for 'vote'
-        channel=alice_dm_channel,
-        author=mock_discord_setup['members']['alice']
-    )
-
-    # Mock GlobalSettings with properly functioning set_alias
-    mock_global_settings = MagicMock()
-    mock_global_settings.set_alias = MagicMock()
-    mock_global_settings.save = MagicMock()
-    mock_global_settings.get_alias = MagicMock(return_value=None)  # Important! This was missing
-
-    # Process the message
-    with patch('bot_impl.backup') as mock_backup:
-        with patch('model.settings.global_settings.GlobalSettings.load', return_value=mock_global_settings):
-            with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
-                # Execute the message handling function
-                await on_message(alice_message)
-
-                # Verify confirmation message was sent (which indicates the command was processed)
-                mock_safe_send.assert_called_with(
-                    mock_discord_setup['members']['alice'],
-                    "Successfully created alias v for command vote."
-                )
-
-
-@pytest.mark.asyncio
 async def test_default_vote_command(mock_discord_setup):
     """Test setting a default vote."""
     # Create a direct message channel for Alice

--- a/tests/model/settings/test_global_settings.py
+++ b/tests/model/settings/test_global_settings.py
@@ -60,3 +60,19 @@ class TestGlobalSettings:
         self.global_settings.save()
         loaded_settings = GlobalSettings.load(TEST_PREFERENCES_FILENAME)
         assert self.global_settings == loaded_settings
+
+    def test_clear_alias_existing(self):
+        self.global_settings.set_alias(1, 'ToRemove', 'SomeCommand')
+        assert self.global_settings.get_alias(1, 'ToRemove') == 'SomeCommand'
+        self.global_settings.clear_alias(1, 'ToRemove')
+        assert self.global_settings.get_alias(1, 'ToRemove') is None
+
+    def test_clear_alias_nonexistent(self):
+        # Should not raise or affect other aliases
+        self.global_settings.clear_alias(1, 'DoesNotExist')
+        assert self.global_settings.get_alias(1, 'TestAlias') == 'AliasedCommand'
+
+    def test_clear_alias_new_player(self):
+        # Should not raise for a player with no aliases
+        self.global_settings.clear_alias(3, 'AnyAlias')
+        assert self.global_settings.get_alias(3, 'AnyAlias') is None


### PR DESCRIPTION
This pull request refactors the `makealias` command to improve its functionality, modularity, and test coverage. The changes include moving the command to a dedicated module, enhancing its capabilities, and adding comprehensive tests. Additionally, a new method for clearing aliases was introduced in the global settings model.

### Refactoring and Feature Enhancements:
* Moved the `makealias` command implementation from `bot_impl.py` to a new module, `commands/utility_commands.py`, and registered it in the command registry. The command now supports listing, creating, and removing aliases with improved error handling and user feedback. [[1]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312L3002-L3023) [[2]](diffhunk://#diff-adca283ceb54c5b13a6de2639fac9b99f422b9663cf09f8f3333be1bfb1a03c4R1-R70) [[3]](diffhunk://#diff-fd5278f3519f1d6fd8cc0a232fc4209eb687bff00ff7353a6e6ed1fc9e57b03bR10)
* Added a new `clear_alias` method to the `GlobalSettings` model to allow removing specific aliases for users.

### Test Coverage Improvements:
* Replaced the outdated `test_makealias_command` with new, detailed tests for the `makealias` command, covering scenarios such as alias creation, removal, listing, and restrictions on aliasing registered commands. [[1]](diffhunk://#diff-5592e672cef095f585fc0083c44cdfb8aafdfc11904a484dfa2b0794b0079f35R1229-R1473) [[2]](diffhunk://#diff-f4e989f55b560fb7861f832119e9d393c5930773230da9a3b282c96691391221L567-L608)
* Added unit tests for the `clear_alias` method in `test_global_settings.py`.
* Introduced a test for the `clear_alias` functionality in `test_settings_functionality.py`.

### Command Registry and Help Updates:
* Removed the old `makealias` command from the `HelpGenerator` and updated the command registry to include the new implementation. [[1]](diffhunk://#diff-426fce22d255302af438d41624c809e13f822eea4199eec19edf630bbbdc4d07L199) [[2]](diffhunk://#diff-fd5278f3519f1d6fd8cc0a232fc4209eb687bff00ff7353a6e6ed1fc9e57b03bR10)