### PR TITLE
refactor: Extract all utility functions from bot_impl

### DIFF
--- a/commands/registry.py
+++ b/commands/registry.py
@@ -9,6 +9,7 @@ import global_vars
 import model.game
 import model.player
 from commands.command_enums import HelpSection, UserType, GamePhase
+from utils import player_utils
 
 
 # =============================================================================
@@ -113,16 +114,6 @@ class CommandInfo(NamedTuple):
 # Validation Functions
 # =============================================================================
 
-async def get_player(user) -> Optional[model.player.Player]:
-    """Get player object for a Discord user."""
-    if global_vars.game is model.game.NULL_GAME:
-        return None
-
-    for person in global_vars.game.seatingOrder:
-        if person.user == user:
-            return person
-
-    return None
 
 
 async def validate_user_type(message: discord.Message, command_info: CommandInfo) -> None:
@@ -151,7 +142,7 @@ async def validate_user_type(message: discord.Message, command_info: CommandInfo
     # Determine what user type this person actually is
     is_storyteller = global_vars.gamemaster_role in member.roles
     is_observer = global_vars.observer_role in member.roles
-    player = await get_player(message.author)
+    player = await player_utils.get_player(message.author)
     is_player = player is not None
 
     # Check if user matches any of the required types

--- a/model/game/vote.py
+++ b/model/game/vote.py
@@ -6,8 +6,7 @@ import discord
 import global_vars
 import model.characters
 import model.settings
-from utils import message_utils
-from utils.character_utils import the_ability
+from utils import character_utils, message_utils, player_utils
 
 
 def in_play_voudon():
@@ -17,7 +16,7 @@ def in_play_voudon():
         The Voudon player if one is in play and not a ghost, otherwise None
     """
     return next((x for x in global_vars.game.seatingOrder if
-                 the_ability(x.character, model.characters.Voudon) and not x.is_ghost), None)
+                 character_utils.the_ability(x.character, model.characters.Voudon) and not x.is_ghost), None)
 
 
 def remove_banshee_nomination(banshee_ability_of_player):
@@ -68,7 +67,7 @@ class Vote:
         order_with_banshees = []
         for person in ordered_voters:
             order_with_banshees.append(person)
-            banshee_ability = the_ability(person.character, model.characters.Banshee)
+            banshee_ability = character_utils.the_ability(person.character, model.characters.Banshee)
             if banshee_ability and banshee_ability.is_screaming:
                 order_with_banshees.append(person)
 
@@ -99,7 +98,7 @@ class Vote:
     async def call_next(self):
         """Calls for person to vote."""
         toCall = self.order[self.position]
-        player_banshee_ability = the_ability(toCall.character, model.characters.Banshee)
+        player_banshee_ability = character_utils.the_ability(toCall.character, model.characters.Banshee)
         player_is_active_banshee = player_banshee_ability and player_banshee_ability.is_screaming
         voudon_is_active = in_play_voudon()
         for person in global_vars.game.seatingOrder:
@@ -165,7 +164,7 @@ class Vote:
         # Update seating order message immediately
         await global_vars.game.update_seating_order_message()
 
-        potential_banshee = the_ability(voter.character, model.characters.Banshee)
+        potential_banshee = character_utils.the_ability(voter.character, model.characters.Banshee)
 
         # see if a Voudon is in play
         voudon_in_play = in_play_voudon()
@@ -334,7 +333,7 @@ class Vote:
             operator: The operator making the preset
         """
         # Check dead votes
-        banshee_ability = the_ability(person.character, model.characters.Banshee)
+        banshee_ability = character_utils.the_ability(person.character, model.characters.Banshee)
         banshee_override = banshee_ability and banshee_ability.is_screaming
         if vt > 0 and person.is_ghost and person.dead_votes < 1 and not banshee_override:
             if not operator:
@@ -375,18 +374,7 @@ class Vote:
         global_vars.game.days[-1].votes.remove(self)
 
 
-async def _generate_member_possibilities(arg, server_members):
-    """Generate possibilities for member names.
-    
-    Args:
-        arg: The string to match against members
-        server_members: The list of members to search
-        
-    Returns:
-        List of members matching the string
-    """
-    from bot_impl import generate_possibilities
-    return await generate_possibilities(arg, server_members)
+# Removed: _generate_member_possibilities is now replaced with direct import
 
 
 async def is_storyteller(arg, member_possibilities_fn=None, server_members=None, server=None, gamemaster_role=None):
@@ -413,9 +401,9 @@ async def is_storyteller(arg, member_possibilities_fn=None, server_members=None,
     _server = server if server is not None else global_vars.server
     _gamemaster_role = gamemaster_role if gamemaster_role is not None else global_vars.gamemaster_role
 
-    # Use provided function or default to the internal one
+    # Use provided function or default to the imported one
     if member_possibilities_fn is None:
-        member_possibilities_fn = _generate_member_possibilities
+        member_possibilities_fn = player_utils.generate_possibilities
 
     # Use provided server_members or get from global_vars
     members = server_members if server_members is not None else _server.members

--- a/model/game/whisper_mode.py
+++ b/model/game/whisper_mode.py
@@ -1,3 +1,6 @@
+from utils import player_utils
+
+
 class WhisperMode:
     """Enum-like class for whisper modes.
     
@@ -39,7 +42,7 @@ def to_whisper_mode(argument):
         return None
 
 
-async def chose_whisper_candidates(game, author):
+async def choose_whisper_candidates(game, author):
     """Determine which players the author can whisper to based on the current whisper mode.
     
     Args:
@@ -49,7 +52,6 @@ async def chose_whisper_candidates(game, author):
     Returns:
         List of players that the author can whisper to
     """
-    from bot_impl import get_player
 
     if game.whisper_mode == WhisperMode.ALL:
         return game.seatingOrder + game.storytellers
@@ -57,7 +59,7 @@ async def chose_whisper_candidates(game, author):
         return game.storytellers
     if game.whisper_mode == WhisperMode.NEIGHBORS:
         # determine neighbors
-        player_self = await get_player(author)
+        player_self = await player_utils.get_player(author)
         author_index = game.seatingOrder.index(player_self)
         neighbor_left = game.seatingOrder[(author_index - 1) % len(game.seatingOrder)]
         neighbor_right = game.seatingOrder[(author_index + 1) % len(game.seatingOrder)]

--- a/tests/commands/test_debug_commands_registry.py
+++ b/tests/commands/test_debug_commands_registry.py
@@ -32,7 +32,7 @@ async def test_ping_command_via_registry(mock_discord_setup, setup_test_game):
     )
 
     # Test the command execution with individual patches
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', AsyncMock()) as mock_safe_send, \
             patch('bot_client.client', mock_discord_setup['client']):
         await on_message(message)
@@ -59,7 +59,7 @@ async def test_test_command_via_registry(mock_discord_setup, setup_test_game):
     )
 
     # Test the command execution with individual patches
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', AsyncMock()) as mock_safe_send, \
             patch('bot_client.client', mock_discord_setup['client']):
         await on_message(message)
@@ -86,7 +86,7 @@ async def test_test_command_no_arguments_via_registry(mock_discord_setup, setup_
     )
 
     # Test the command execution with individual patches
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', AsyncMock()) as mock_safe_send, \
             patch('bot_client.client', mock_discord_setup['client']):
         await on_message(message)
@@ -128,7 +128,7 @@ async def test_info_commands_in_dm_channel(mock_discord_setup, setup_test_game):
     )
 
     # Test the command execution with individual patches
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', AsyncMock()) as mock_safe_send, \
             patch('bot_client.client', mock_discord_setup['client']):
         await on_message(message)
@@ -155,7 +155,7 @@ async def test_info_commands_case_insensitive(mock_discord_setup, setup_test_gam
     )
 
     # Test the command execution - should work since bot_impl converts commands to lowercase
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', AsyncMock()) as mock_safe_send, \
             patch('bot_client.client', mock_discord_setup['client']):
         await on_message(message)
@@ -183,7 +183,7 @@ async def test_info_commands_with_extra_whitespace(mock_discord_setup, setup_tes
     )
 
     # Test the command execution with individual patches
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', AsyncMock()) as mock_safe_send, \
             patch('bot_client.client', mock_discord_setup['client']):
         await on_message(message)
@@ -211,7 +211,7 @@ async def test_registry_prevents_legacy_command_processing(mock_discord_setup, s
 
     # Mock a function that would be called in legacy command processing
     # to verify it's not reached when registry handles the command
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', AsyncMock()) as mock_safe_send, \
             patch('bot_client.client', mock_discord_setup['client']), \
             patch('model.settings.global_settings.GlobalSettings.load') as mock_global_settings:
@@ -247,7 +247,7 @@ async def test_registry_commands_only_work_in_dms(mock_discord_setup, setup_test
     )
 
     # Test the command execution with individual patches
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', AsyncMock()) as mock_safe_send, \
             patch('bot_client.client', mock_discord_setup['client']):
         await on_message(message)

--- a/tests/core/test_backup_functions.py
+++ b/tests/core/test_backup_functions.py
@@ -7,8 +7,10 @@ from unittest.mock import patch, MagicMock, mock_open, AsyncMock
 import pytest
 
 import global_vars
-from bot_impl import backup, load, remove_backup, Game, Script
+from model import Game
+from model.game import Script
 from tests.fixtures.discord_mocks import mock_discord_setup
+from utils import backup, load, remove_backup
 
 
 def test_backup():

--- a/tests/core/test_game_class.py
+++ b/tests/core/test_game_class.py
@@ -8,9 +8,9 @@ import discord.errors
 import pytest
 
 import global_vars
-from bot_impl import Game, Player, Script
+from model import Game, Player
 from model.characters import Character
-from model.game import Day
+from model.game import Day, Script
 from tests.fixtures.discord_mocks import mock_discord_setup, MockChannel
 from tests.fixtures.game_fixtures import setup_test_game
 

--- a/tests/discord/test_on_message.py
+++ b/tests/discord/test_on_message.py
@@ -23,7 +23,7 @@ from tests.fixtures.game_fixtures import setup_test_game
 async def test_on_message_bot_message(mock_discord_setup):
     """Test that bot ignores its own messages."""
     # Initialize global_vars.game to NULL_GAME
-    from bot_impl import NULL_GAME
+    from model import NULL_GAME
     global_vars.game = NULL_GAME
 
     # Create a message from the bot
@@ -36,7 +36,7 @@ async def test_on_message_bot_message(mock_discord_setup):
     )
 
     # Set up spy on backup function
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         # Process the message with client set as author
         with patch('bot_client.client') as mock_client:
             mock_client.user = bot_message.author  # This makes the bot recognize itself
@@ -63,8 +63,8 @@ async def test_on_message_town_square_activity(mock_discord_setup, setup_test_ga
     )
 
     # Set up mock for make_active function
-    with patch('bot_impl.make_active') as mock_make_active:
-        with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.player_utils.make_active') as mock_make_active:
+        with patch('utils.game_utils.backup') as mock_backup:
             # Process the message
             await on_message(alice_message)
 
@@ -95,9 +95,9 @@ async def test_on_message_storyteller_channel(mock_discord_setup, setup_test_gam
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('model.settings.game_settings.GameSettings.load', return_value=mock_game_settings):
-            with patch('bot_impl.active_in_st_chat') as mock_active_in_st_chat:
+            with patch('utils.player_utils.active_in_st_chat') as mock_active_in_st_chat:
                 await on_message(alice_message)
 
                 # Verify active_in_st_chat was called for Alice
@@ -108,7 +108,7 @@ async def test_on_message_storyteller_channel(mock_discord_setup, setup_test_gam
 async def test_on_message_vote_command_no_game(mock_discord_setup):
     """Test handling vote command when no game is active."""
     # Set up global variables
-    from bot_impl import NULL_GAME
+    from model.game import NULL_GAME
     global_vars.game = NULL_GAME  # Use NULL_GAME instead of None
     global_vars.channel = mock_discord_setup['channels']['town_square']
 
@@ -122,7 +122,7 @@ async def test_on_message_vote_command_no_game(mock_discord_setup):
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
             await on_message(alice_message)
 
@@ -153,7 +153,7 @@ async def test_on_message_vote_command_nighttime(mock_discord_setup, setup_test_
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
             await on_message(alice_message)
 
@@ -186,7 +186,7 @@ async def test_on_message_vote_command_no_votes(mock_discord_setup, setup_test_g
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
             await on_message(alice_message)
 
@@ -220,7 +220,7 @@ async def test_on_message_vote_invalid_format(mock_discord_setup, setup_test_gam
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
             await on_message(alice_message)
 
@@ -260,9 +260,9 @@ async def test_on_message_vote_not_player_turn(mock_discord_setup, setup_test_ga
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
-            with patch('bot_impl.get_player', return_value=setup_test_game['players']['alice']):
+            with patch('utils.player_utils.get_player', return_value=setup_test_game['players']['alice']):
                 await on_message(alice_message)
 
                 # Verify error message was sent
@@ -302,9 +302,9 @@ async def test_on_message_vote_successful(mock_discord_setup, setup_test_game):
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
-        with patch('bot_impl.get_player', return_value=setup_test_game['players']['alice']):
-            with patch('bot_impl.in_play_voudon', return_value=None):  # No Voudon in play
+    with patch('utils.game_utils.backup') as mock_backup:
+        with patch('utils.player_utils.get_player', return_value=setup_test_game['players']['alice']):
+            with patch('model.game.vote.in_play_voudon', return_value=None):  # No Voudon in play
                 await on_message(alice_message)
 
                 # Verify vote was called with 1 (yes)
@@ -334,7 +334,7 @@ async def test_direct_message_command_processing(mock_discord_setup, setup_test_
     global_vars.server = mock_server
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('discord.Embed') as mock_embed:
             mock_embed_instance = MagicMock()
             mock_embed.return_value = mock_embed_instance
@@ -392,10 +392,11 @@ async def test_pm_command_during_day(mock_discord_setup, setup_test_game):
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
-        with patch('bot_impl.get_player', return_value=setup_test_game['players']['alice']):
-            with patch('bot_impl.select_player', return_value=setup_test_game['players']['bob']):
-                with patch('bot_impl.chose_whisper_candidates', return_value=[setup_test_game['players']['bob']]):
+    with patch('utils.game_utils.backup') as mock_backup:
+        with patch('utils.player_utils.get_player', return_value=setup_test_game['players']['alice']):
+            with patch('utils.player_utils.select_player', return_value=setup_test_game['players']['bob']):
+                with patch('model.game.whisper_mode.choose_whisper_candidates',
+                           return_value=[setup_test_game['players']['bob']]):
                     with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
                         # Create a proper async mock for client.wait_for
                         wait_for_mock = AsyncMock()
@@ -439,8 +440,8 @@ async def test_pm_command_when_pms_closed(mock_discord_setup, setup_test_game):
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
-        with patch('bot_impl.get_player', return_value=setup_test_game['players']['alice']):
+    with patch('utils.game_utils.backup') as mock_backup:
+        with patch('utils.player_utils.get_player', return_value=setup_test_game['players']['alice']):
             with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
                 await on_message(alice_message)
 
@@ -457,7 +458,7 @@ async def test_command_parser_handles_nominate(mock_discord_setup):
 
     # This is a very simplified test that just verifies command recognition
     # Set up global variables for this test
-    from bot_impl import NULL_GAME
+    from model.game import NULL_GAME
     global_vars.game = NULL_GAME
 
     # Create a nominate message from Alice (but without all the game setup)
@@ -471,7 +472,7 @@ async def test_command_parser_handles_nominate(mock_discord_setup):
 
     # Since we're not really trying to properly test the full nomination functionality
     # we'll just track that the backup function got called, indicating message processing ran
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         await on_message(alice_message)
 
         # If this assertion passes, it means on_message recognized the command
@@ -511,7 +512,7 @@ async def test_openpms_command_from_storyteller(mock_discord_setup, setup_test_g
     global_vars.gamemaster_role = mock_member.roles[0]
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
             await on_message(st_message)
 
@@ -553,8 +554,8 @@ async def test_whispers_command(mock_discord_setup, setup_test_game):
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
-        with patch('bot_impl.get_player', return_value=setup_test_game['players']['alice']):
+    with patch('utils.game_utils.backup') as mock_backup:
+        with patch('utils.player_utils.get_player', return_value=setup_test_game['players']['alice']):
             with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
                 # Create OrderedDict for counts (this is used in the function)
                 with patch('bot_impl.OrderedDict', return_value={}):
@@ -593,7 +594,7 @@ async def test_default_vote_command(mock_discord_setup):
     mock_global_settings.get_alias = MagicMock(return_value=None)  # Important! This was missing
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('model.settings.global_settings.GlobalSettings.load', return_value=mock_global_settings):
             with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
                 # Execute the message handling function
@@ -636,9 +637,9 @@ async def test_history_command(mock_discord_setup, setup_test_game):
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
-        with patch('bot_impl.get_player', return_value=setup_test_game['players']['alice']):
-            with patch('bot_impl.select_player', return_value=setup_test_game['players']['bob']):
+    with patch('utils.game_utils.backup') as mock_backup:
+        with patch('utils.player_utils.get_player', return_value=setup_test_game['players']['alice']):
+            with patch('utils.player_utils.select_player', return_value=setup_test_game['players']['bob']):
                 with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
                     await on_message(alice_message)
 
@@ -672,8 +673,8 @@ async def test_skip_command(mock_discord_setup, setup_test_game):
     alice_message.pin = AsyncMock()
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
-        with patch('bot_impl.get_player', return_value=setup_test_game['players']['alice']):
+    with patch('utils.game_utils.backup') as mock_backup:
+        with patch('utils.player_utils.get_player', return_value=setup_test_game['players']['alice']):
             with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
                 await on_message(alice_message)
 
@@ -698,7 +699,7 @@ async def test_clear_command(mock_discord_setup):
     )
 
     # Process the message
-    with patch('bot_impl.backup') as mock_backup:
+    with patch('utils.game_utils.backup') as mock_backup:
         with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
             await on_message(alice_message)
 

--- a/tests/fixtures/command_testing.py
+++ b/tests/fixtures/command_testing.py
@@ -15,7 +15,7 @@ from tests.fixtures.discord_mocks import MockMessage
 async def execute_command(command_function, message):
     """Execute a command with the given message."""
     # Patch multiple functions needed for commands to work
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', new_callable=AsyncMock) as mock_safe_send:
         # Execute the command
         await command_function(message)
@@ -111,8 +111,8 @@ async def run_command_vote(vote_type, voter, vote, cmd_function=None):
     vote.vote = AsyncMock()
 
     # Mock get_player function to return the voter
-    with patch('bot_impl.get_player', return_value=voter), \
-            patch('bot_impl.backup', return_value=None), \
+    with patch('utils.player_utils.get_player', return_value=voter), \
+            patch('utils.game_utils.backup', return_value=None), \
             patch('utils.message_utils.safe_send', new_callable=AsyncMock):
             # Process the message
             await cmd_function(message)
@@ -174,7 +174,7 @@ async def execute_command_with_wait_for(command_function, message, mock_discord_
             mock_discord_setup['client'].wait_for = AsyncMock(side_effect=wait_for_responses)
 
     # Use individual patches for command execution
-    with patch('bot_impl.backup'), \
+    with patch('utils.game_utils.backup'), \
             patch('utils.message_utils.safe_send', AsyncMock()), \
             patch('bot_client.client', mock_discord_setup['client']):
         await command_function(message)

--- a/tests/fixtures/common_patches.py
+++ b/tests/fixtures/common_patches.py
@@ -26,8 +26,8 @@ import pytest
 def backup_patches_combined():
     """Return patches that disable backup functionality."""
     return [
-        patch('bot_impl.backup', return_value=None),
-        patch('bot_impl.remove_backup', return_value=None),
+        patch('utils.game_utils.backup', return_value=None),
+        patch('utils.game_utils.remove_backup', return_value=None),
     ]
 
 
@@ -204,7 +204,7 @@ def full_bot_setup_patches_combined(mock_discord_setup, with_backup=False, backu
     if with_backup:
         patches.extend([
             patch('os.path.isfile', return_value=True),
-            patch('bot_impl.load', return_value=backup_game)
+            patch('utils.game_utils.load', return_value=backup_game)
         ])
     else:
         patches.append(patch('os.path.isfile', return_value=False))

--- a/tests/fixtures/game_fixtures.py
+++ b/tests/fixtures/game_fixtures.py
@@ -28,7 +28,7 @@ async def setup_test_game(mock_discord_setup):
     day = create_mocked_day()
 
     # Mock the start_day and end methods to avoid Discord API calls
-    with patch('bot_impl.update_presence'):
+    with patch('utils.game_utils.update_presence'):
         # Create game object with patched methods
         game = Game(
             seating_order=[players['alice'], players['bob'], players['charlie']],

--- a/tests/utils/test_player_utils.py
+++ b/tests/utils/test_player_utils.py
@@ -8,10 +8,12 @@ from unittest.mock import AsyncMock, MagicMock, patch, Mock, call
 import discord
 import pytest
 
-from bot_impl import generate_possibilities, select_player, choices, yes_no, get_player
-from utils.player_utils import (is_player, find_player_by_nick, who_by_id,
-                                who_by_character, who, get_neighbors,
-                                check_and_print_if_one_or_zero_to_check_in)
+from utils.interaction_utils import yes_no
+from utils.player_utils import (
+    is_player, find_player_by_nick, who_by_id, who_by_character, who, get_neighbors,
+    check_and_print_if_one_or_zero_to_check_in, generate_possibilities,
+    select_player, choices, get_player
+)
 
 
 # Common test fixtures and setup
@@ -173,9 +175,9 @@ async def test_select_player_exact_match(mock_players):
     user = MagicMock()
 
     # Patch generate_possibilities to return a single player
-    with patch('bot_impl.generate_possibilities', new_callable=AsyncMock) as mock_gen_poss:
+    with patch('utils.player_utils.generate_possibilities', new_callable=AsyncMock) as mock_gen_poss:
         with patch('utils.message_utils.safe_send', new_callable=AsyncMock) as mock_safe_send:
-            with patch('bot_impl.choices', new_callable=AsyncMock) as mock_choices:
+            with patch('utils.player_utils.choices', new_callable=AsyncMock) as mock_choices:
                 # Mock return value
                 mock_gen_poss.return_value = [mock_players[0]]
 
@@ -201,7 +203,7 @@ async def test_select_player_no_match():
     players = []
 
     # Patch generate_possibilities to return empty list
-    with patch('bot_impl.generate_possibilities', new_callable=AsyncMock) as mock_gen_poss:
+    with patch('utils.player_utils.generate_possibilities', new_callable=AsyncMock) as mock_gen_poss:
         with patch('utils.message_utils.safe_send', new_callable=AsyncMock) as mock_safe_send:
             # Mock return value
             mock_gen_poss.return_value = []
@@ -225,8 +227,8 @@ async def test_select_player_multiple_matches(mock_players):
     user = MagicMock()
 
     # Patch generate_possibilities and choices
-    with patch('bot_impl.generate_possibilities', new_callable=AsyncMock) as mock_gen_poss:
-        with patch('bot_impl.choices', new_callable=AsyncMock) as mock_choices:
+    with patch('utils.player_utils.generate_possibilities', new_callable=AsyncMock) as mock_gen_poss:
+        with patch('utils.player_utils.choices', new_callable=AsyncMock) as mock_choices:
             # Mock generate_possibilities to return multiple players
             mock_gen_poss.return_value = mock_players[:2]  # Alice and Bob
 
@@ -288,7 +290,7 @@ async def test_get_player_found(mock_wait_for, mock_safe_send):
     player = MagicMock()
 
     # Mock the global game object and seating order
-    with patch('bot_impl.global_vars') as mock_global_vars:
+    with patch('utils.player_utils.global_vars') as mock_global_vars:
         mock_global_vars.game.seatingOrder = [player]
         player.user = user
 
@@ -310,7 +312,7 @@ async def test_get_player_not_found(mock_wait_for, mock_safe_send):
     player = MagicMock()
 
     # Mock the global game object and seating order
-    with patch('bot_impl.global_vars') as mock_global_vars:
+    with patch('utils.player_utils.global_vars') as mock_global_vars:
         mock_global_vars.game.seatingOrder = [player]
         player.user = other_user  # Different user
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -5,20 +5,30 @@ This module provides utility functions for character abilities, game state manag
 message handling, and player operations.
 """
 
+# Make modules available for direct import
+from . import interaction_utils
+from . import text_utils
 # Import commonly used functions
-from .character_utils import has_ability, the_ability
-from .game_utils import remove_backup, update_presence
+from .character_utils import has_ability, the_ability, str_to_class
+from .game_utils import remove_backup, update_presence, backup, load
 from .message_utils import safe_send, safe_send_dm, notify_storytellers
-from .player_utils import who, find_player_by_nick, is_player
+from .player_utils import (
+    who, find_player_by_nick, is_player, get_player, generate_possibilities,
+    choices, select_player, active_in_st_chat, make_active, cannot_nominate,
+    warn_missing_player_channels, check_and_print_if_one_or_zero_to_check_in
+)
 
 __all__ = [
     # Character utilities
     'has_ability',
     'the_ability',
+    'str_to_class',
 
     # Game utilities  
     'remove_backup',
     'update_presence',
+    'backup',
+    'load',
 
     # Message utilities
     'safe_send',
@@ -28,5 +38,14 @@ __all__ = [
     # Player utilities
     'who',
     'find_player_by_nick',
-    'is_player'
+    'is_player',
+    'get_player',
+    'generate_possibilities',
+    'choices',
+    'select_player',
+    'active_in_st_chat',
+    'make_active',
+    'cannot_nominate',
+    'warn_missing_player_channels',
+    'check_and_print_if_one_or_zero_to_check_in'
 ]

--- a/utils/character_utils.py
+++ b/utils/character_utils.py
@@ -1,5 +1,24 @@
 """Utilities for character-related functionality."""
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from model.characters.base import Character
+
+
+def str_to_class(role: str) -> type['Character']:
+    """
+    Convert a role string to a character class.
+    
+    Args:
+        role: The role string to convert
+        
+    Returns:
+        The character class corresponding to the role
+    """
+    from model.characters.registry import str_to_class as registry_str_to_class
+    return registry_str_to_class(role)
+
 
 def the_ability(character, ability_class):
     """Get an ability from a character if it has that ability.

--- a/utils/game_utils.py
+++ b/utils/game_utils.py
@@ -2,6 +2,7 @@
 
 import os
 
+import dill
 import discord
 
 import global_vars
@@ -60,3 +61,80 @@ def remove_backup(fileName):
         obj_file = obj + "_" + fileName
         if os.path.exists(obj_file):
             os.remove(obj_file)
+
+
+def backup(fileName):
+    """
+    Backs up the game-state.
+    
+    Args:
+        fileName: The name of the backup file
+    """
+    from model.game.game import NULL_GAME
+
+    if not global_vars.game or global_vars.game is NULL_GAME:
+        return
+
+    objects = [
+        x
+        for x in dir(global_vars.game)
+        if not x.startswith("__") and not callable(getattr(global_vars.game, x))
+    ]
+    with open(fileName, "wb") as file:
+        dill.dump(objects, file)
+
+    for obj in objects:
+        with open(obj + "_" + fileName, "wb") as file:
+            if obj == "seatingOrderMessage":
+                dill.dump(getattr(global_vars.game, obj).id, file)
+            elif obj == "info_channel_seating_order_message":
+                msg = getattr(global_vars.game, obj)
+                if msg is not None:
+                    dill.dump(msg.id, file)
+                else:
+                    dill.dump(None, file)
+            else:
+                dill.dump(getattr(global_vars.game, obj), file)
+
+
+async def load(fileName):
+    """
+    Loads the game-state.
+    
+    Args:
+        fileName: The name of the backup file
+        
+    Returns:
+        The loaded game object
+    """
+    from model.game.game import Game
+    from model.game.script import Script
+
+    with open(fileName, "rb") as file:
+        objects = dill.load(file)
+
+    game = Game([], None, None, Script([]))
+    for obj in objects:
+        if not os.path.isfile(obj + "_" + fileName):
+            print("Incomplete backup found.")
+            return None
+        with open(obj + "_" + fileName, "rb") as file:
+            if obj == "seatingOrderMessage":
+                id = dill.load(file)
+                msg = await global_vars.channel.fetch_message(id)
+                setattr(game, obj, msg)
+            elif obj == "info_channel_seating_order_message":
+                id = dill.load(file)
+                if id is not None and global_vars.info_channel:
+                    try:
+                        msg = await global_vars.info_channel.fetch_message(id)
+                        setattr(game, obj, msg)
+                    except:
+                        # Message may have been deleted or channel may not exist
+                        setattr(game, obj, None)
+                else:
+                    setattr(game, obj, None)
+            else:
+                setattr(game, obj, dill.load(file))
+
+    return game

--- a/utils/interaction_utils.py
+++ b/utils/interaction_utils.py
@@ -1,0 +1,52 @@
+"""
+Utility functions for user interactions.
+"""
+
+import asyncio
+
+import discord
+
+import bot_client
+from utils import message_utils
+
+
+async def yes_no(user: discord.User, text: str):
+    """
+    Ask a yes or no question of a user.
+    
+    Args:
+        user: The Discord user to ask
+        text: The question text
+        
+    Returns:
+        True for yes, False for no, None for timeout/cancel
+    """
+    reply = await message_utils.safe_send(user, "{}? yes or no".format(text))
+    try:
+        choice = await bot_client.client.wait_for(
+            "message",
+            check=(lambda x: x.author == user and x.channel == reply.channel),
+            timeout=200,
+        )
+    except asyncio.TimeoutError:
+        await message_utils.safe_send(user, "Timed out.")
+        return None
+
+    # Cancel
+    if choice.content.lower() == "cancel":
+        await message_utils.safe_send(user, "Action cancelled!")
+        return None
+
+    # Yes
+    if choice.content.lower() == "yes" or choice.content.lower() == "y":
+        return True
+
+    # No
+    elif choice.content.lower() == "no" or choice.content.lower() == "n":
+        return False
+
+    else:
+        await message_utils.safe_send(
+            user, "Your answer must be 'yes,' 'y,' 'no,' or 'n' exactly. Try again."
+        )
+        return None

--- a/utils/player_utils.py
+++ b/utils/player_utils.py
@@ -2,13 +2,18 @@
 Utility functions for player management.
 """
 
-from typing import List, Optional
+import asyncio
+from typing import List, Optional, Sequence, TypeVar
 
 import discord
 
+import bot_client
 import global_vars
 import model.player
+from model import game
 from utils import message_utils
+
+T = TypeVar('T')
 
 
 def is_player(member: discord.Member) -> bool:
@@ -156,10 +161,12 @@ def get_neighbors(player: model.player.Player) -> List[model.player.Player]:
 
 async def check_and_print_if_one_or_zero_to_check_in() -> None:
     """Check and notify storytellers if only one or zero players need to check in."""
+    from model.player import STORYTELLER_ALIGNMENT
+    
     not_checked_in = [
         player
         for player in global_vars.game.seatingOrder
-        if not player.has_checked_in and player.alignment != "neutral"
+        if not player.has_checked_in and player.alignment != STORYTELLER_ALIGNMENT
     ]
     
     if len(not_checked_in) == 1:
@@ -171,3 +178,217 @@ async def check_and_print_if_one_or_zero_to_check_in() -> None:
     elif len(not_checked_in) == 0:
         for member in global_vars.gamemaster_role.members:
             await message_utils.safe_send(member, "Everyone has checked in!")
+
+
+async def get_player(user) -> Optional[model.player.Player]:
+    """
+    Returns the Player object corresponding to user.
+    
+    Args:
+        user: The Discord user
+        
+    Returns:
+        The Player object if found, None otherwise
+    """
+    if global_vars.game is game.NULL_GAME:
+        return None
+
+    for person in global_vars.game.seatingOrder:
+        if person.user == user:
+            return person
+
+    return None
+
+
+async def generate_possibilities(text: str, people: Sequence[T]) -> List[T]:
+    """
+    Generates possible users with name or nickname matching text.
+    
+    Args:
+        text: The text to match against
+        people: The sequence of people to search through
+        
+    Returns:
+        List of matching people
+    """
+    possibilities = []
+    for person in people:
+        if (
+                person.display_name is not None and text.lower() in person.display_name.lower()
+        ) or text.lower() in person.name.lower():
+            possibilities.append(person)
+    return possibilities
+
+
+async def select_player(user: discord.User, text: str, possibilities: Sequence[T]) -> Optional[T]:
+    """
+    Finds a player from players matching a string.
+    
+    Args:
+        user: The Discord user making the selection
+        text: The text to match
+        possibilities: The sequence of possible matches
+        
+    Returns:
+        The selected player if found, None otherwise
+    """
+    new_possibilities = await generate_possibilities(text, possibilities)
+
+    # If no users found
+    if len(new_possibilities) == 0:
+        await message_utils.safe_send(user, "User {} not found. Try again!".format(text))
+        return None
+
+    # If exactly one user found
+    elif len(new_possibilities) == 1:
+        return new_possibilities[0]
+
+    # If too many users found
+    elif len(new_possibilities) > 1:
+        return await choices(user, new_possibilities, text)
+
+
+async def choices(user: discord.User, possibilities: List[model.player.Player], text: str) -> Optional[
+    model.player.Player]:
+    """
+    Clarifies which user is intended when there are multiple matches.
+    
+    Args:
+        user: The Discord user making the choice
+        possibilities: List of possible players
+        text: The original search text
+        
+    Returns:
+        The chosen player if selected, None otherwise
+    """
+    # Generate clarification message
+    if text == "":
+        message_text = "Who do you mean? or use 'cancel'"
+    else:
+        message_text = "Who do you mean by {}? or use 'cancel'".format(text)
+    for index, person in enumerate(possibilities):
+        message_text += "\n({}). {}".format(
+            index + 1, person.display_name if person.display_name else person.name
+        )
+
+    # Request clarification from user
+    reply = await message_utils.safe_send(user, message_text)
+    try:
+        choice = await bot_client.client.wait_for(
+            "message",
+            check=(lambda x: x.author == user and x.channel == reply.channel),
+            timeout=200,
+        )
+    except asyncio.TimeoutError:
+        await message_utils.safe_send(user, "Timed out.")
+        return None
+
+    # Cancel
+    if choice.content.lower() == "cancel":
+        await message_utils.safe_send(user, "Action cancelled!")
+        return None
+
+    # If a is an int
+    try:
+        return possibilities[int(choice.content) - 1]
+
+    # If a is a name
+    except Exception:
+        return await select_player(user, choice.content, possibilities)
+
+
+async def active_in_st_chat(user):
+    """
+    Makes user active in storyteller chat.
+    
+    Args:
+        user: The Discord user
+    """
+    person: model.player.Player = await get_player(user)
+
+    if not person:
+        return
+
+    # updates last active timestamp when posting in ST chat.
+    person.update_last_active()
+
+    if person.has_checked_in or global_vars.game.isDay:
+        return
+
+    person.has_checked_in = True
+    await check_and_print_if_one_or_zero_to_check_in()
+
+
+async def make_active(user):
+    """
+    Makes user active during the day.
+    
+    Args:
+        user: The Discord user
+    """
+    if not await get_player(user):
+        return
+
+    person = await get_player(user)
+    person.update_last_active()
+
+    if person.is_active or not global_vars.game.isDay:
+        return
+
+    person.is_active = True
+    from model.player import STORYTELLER_ALIGNMENT
+
+    notActive = [
+        player
+        for player in global_vars.game.seatingOrder
+        if player.is_active == False and player.alignment != STORYTELLER_ALIGNMENT
+    ]
+    if len(notActive) == 1:
+        for memb in global_vars.gamemaster_role.members:
+            await message_utils.safe_send(
+                memb, "Just waiting on {} to speak.".format(notActive[0].display_name)
+            )
+    if len(notActive) == 0:
+        for memb in global_vars.gamemaster_role.members:
+            await message_utils.safe_send(memb, "Everyone has spoken!")
+
+
+async def cannot_nominate(user):
+    """
+    Uses user's nomination.
+    
+    Args:
+        user: The Discord user
+    """
+    (await get_player(user)).can_nominate = False
+    can_nominate = [
+        player
+        for player in global_vars.game.seatingOrder
+        if player.can_nominate == True
+           and player.has_skipped == False
+           and player.is_ghost == False
+    ]
+    if len(can_nominate) == 1:
+        for memb in global_vars.gamemaster_role.members:
+            await message_utils.safe_send(
+                memb,
+                "Just waiting on {} to nominate or skip.".format(can_nominate[0].display_name),
+            )
+    if len(can_nominate) == 0:
+        for memb in global_vars.gamemaster_role.members:
+            await message_utils.safe_send(memb, "Everyone has nominated or skipped!")
+
+
+async def warn_missing_player_channels(channel_to_send, players_missing_channels):
+    """
+    Warn about missing player channels.
+    
+    Args:
+        channel_to_send: The channel to send the warning to
+        players_missing_channels: List of players missing channels
+    """
+    plural = len(players_missing_channels) > 1
+    chan = "channels" if plural else "a channel"
+    playz = "those players" if plural else "that player"
+    await message_utils.safe_send(channel_to_send,
+                                  f"Missing {chan} for: {', '.join([x.display_name for x in players_missing_channels])}.  Please run `@welcome` for {playz} to create {chan} for them.")

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -1,0 +1,43 @@
+"""
+Utility functions for text processing and manipulation.
+"""
+
+from typing import Generator
+
+
+def str_cleanup(text: str, chars: list[str]) -> str:
+    """
+    Cleanup a string by splitting on specified characters and capitalizing each part.
+    
+    Args:
+        text: The text to clean up
+        chars: List of characters to split on
+        
+    Returns:
+        The cleaned up string with each part capitalized
+    """
+    parts = [text]
+    for char in chars:
+        new_parts = []
+        for part in parts:
+            for sub_part in part.split(char):
+                new_parts.append(sub_part)
+        parts = new_parts
+    return "".join([part.capitalize() for part in parts])
+
+
+def find_all(pattern: str, text: str) -> Generator[int, None, None]:
+    """
+    Find all occurrences of a pattern in text.
+    
+    Args:
+        pattern: The pattern to search for
+        text: The text to search in
+        
+    Yields:
+        The index of each occurrence
+    """
+    i = text.find(pattern)
+    while i != -1:
+        yield i
+        i = text.find(pattern, i + 1)


### PR DESCRIPTION
This pull request refactors code to improve modularity and maintainability by consolidating utility functions into the `utils` package and updating references throughout the codebase. It also includes changes to tests to ensure compatibility with the refactored code.

### Code Refactoring and Utility Consolidation:

* [`commands/registry.py`](diffhunk://#diff-3986cf384adebd590bffd8106f5b1fa609a1b04401e55bc78a8b3707818e2a7eR12): Removed the local `get_player` function and replaced it with `player_utils.get_player` from the `utils` package. Updated import statements to include `player_utils`. [[1]](diffhunk://#diff-3986cf384adebd590bffd8106f5b1fa609a1b04401e55bc78a8b3707818e2a7eR12) [[2]](diffhunk://#diff-3986cf384adebd590bffd8106f5b1fa609a1b04401e55bc78a8b3707818e2a7eL116-L125) [[3]](diffhunk://#diff-3986cf384adebd590bffd8106f5b1fa609a1b04401e55bc78a8b3707818e2a7eL154-R145)
* [`model/game/vote.py`](diffhunk://#diff-de8c2097a60cf142cb68b20b2aa6b445e03b70336bd5f4b532734cee7bc7e99fL9-R9): Replaced direct calls to `the_ability` with `character_utils.the_ability` from the `utils` package. Removed `_generate_member_possibilities` and replaced it with `player_utils.generate_possibilities`. Updated import statements accordingly. [[1]](diffhunk://#diff-de8c2097a60cf142cb68b20b2aa6b445e03b70336bd5f4b532734cee7bc7e99fL9-R9) [[2]](diffhunk://#diff-de8c2097a60cf142cb68b20b2aa6b445e03b70336bd5f4b532734cee7bc7e99fL20-R19) [[3]](diffhunk://#diff-de8c2097a60cf142cb68b20b2aa6b445e03b70336bd5f4b532734cee7bc7e99fL71-R70) [[4]](diffhunk://#diff-de8c2097a60cf142cb68b20b2aa6b445e03b70336bd5f4b532734cee7bc7e99fL102-R101) [[5]](diffhunk://#diff-de8c2097a60cf142cb68b20b2aa6b445e03b70336bd5f4b532734cee7bc7e99fL168-R167) [[6]](diffhunk://#diff-de8c2097a60cf142cb68b20b2aa6b445e03b70336bd5f4b532734cee7bc7e99fL337-R336) [[7]](diffhunk://#diff-de8c2097a60cf142cb68b20b2aa6b445e03b70336bd5f4b532734cee7bc7e99fL378-R377) [[8]](diffhunk://#diff-de8c2097a60cf142cb68b20b2aa6b445e03b70336bd5f4b532734cee7bc7e99fL416-R406)
* [`model/game/whisper_mode.py`](diffhunk://#diff-ac15c130709c37d8beb23652e2aa7c245f958beb12967c5c0f76d59e37827de7R1-R3): Updated `chose_whisper_candidates` to use `player_utils.get_player` and updated import statements to include `player_utils`. Renamed the function to `choose_whisper_candidates` for clarity. [[1]](diffhunk://#diff-ac15c130709c37d8beb23652e2aa7c245f958beb12967c5c0f76d59e37827de7R1-R3) [[2]](diffhunk://#diff-ac15c130709c37d8beb23652e2aa7c245f958beb12967c5c0f76d59e37827de7L42-R45) [[3]](diffhunk://#diff-ac15c130709c37d8beb23652e2aa7c245f958beb12967c5c0f76d59e37827de7L52-R62)

### Test Updates:

* [`tests/commands/test_debug_commands_registry.py`](diffhunk://#diff-98a67aa0797d2a746cc4c151206658be86eb861d915faeda34639cec4dd6f62dL35-R35): Updated patches to use `utils.game_utils.backup` instead of `bot_impl.backup` across multiple test cases. [[1]](diffhunk://#diff-98a67aa0797d2a746cc4c151206658be86eb861d915faeda34639cec4dd6f62dL35-R35) [[2]](diffhunk://#diff-98a67aa0797d2a746cc4c151206658be86eb861d915faeda34639cec4dd6f62dL62-R62) [[3]](diffhunk://#diff-98a67aa0797d2a746cc4c151206658be86eb861d915faeda34639cec4dd6f62dL89-R89) [[4]](diffhunk://#diff-98a67aa0797d2a746cc4c151206658be86eb861d915faeda34639cec4dd6f62dL131-R131) [[5]](diffhunk://#diff-98a67aa0797d2a746cc4c151206658be86eb861d915faeda34639cec4dd6f62dL158-R158) [[6]](diffhunk://#diff-98a67aa0797d2a746cc4c151206658be86eb861d915faeda34639cec4dd6f62dL186-R186) [[7]](diffhunk://#diff-98a67aa0797d2a746cc4c151206658be86eb861d915faeda34639cec4dd6f62dL214-R214) [[8]](diffhunk://#diff-98a67aa0797d2a746cc4c151206658be86eb861d915faeda34639cec4dd6f62dL250-R250)
* [`tests/commands/test_player_commands.py`](diffhunk://#diff-d1290e2be4fe20c63c61f1fcb7b1ff77623c352da567474de1df0596e3e0c543L15-R16): Updated patches to use `utils.player_utils.get_player` and `utils.game_utils.backup` instead of `bot_impl` functions. Updated imports to ensure compatibility with the refactored code. [[1]](diffhunk://#diff-d1290e2be4fe20c63c61f1fcb7b1ff77623c352da567474de1df0596e3e0c543L15-R16) [[2]](diffhunk://#diff-d1290e2be4fe20c63c61f1fcb7b1ff77623c352da567474de1df0596e3e0c543L53-R55) [[3]](diffhunk://#diff-d1290e2be4fe20c63c61f1fcb7b1ff77623c352da567474de1df0596e3e0c543L70-R73) [[4]](diffhunk://#diff-d1290e2be4fe20c63c61f1fcb7b1ff77623c352da567474de1df0596e3e0c543L174-R177) [[5]](diffhunk://#diff-d1290e2be4fe20c63c61f1fcb7b1ff77623c352da567474de1df0596e3e0c543L212-R215) [[6]](diffhunk://#diff-d1290e2be4fe20c63c61f1fcb7b1ff77623c352da567474de1df0596e3e0c543L273-R276) [[7]](diffhunk://#diff-d1290e2be4fe20c63c61f1fcb7b1ff77623c352da567474de1df0596e3e0c543L331-R335) [[8]](diffhunk://#diff-d1290e2be4fe20c63c61f1fcb7b1ff77623c352da567474de1df0596e3e0c543L384-R388)