### PR TITLE
feat: Extract shared voting logic to use BaseVote class, extend the hand raise based on voting logic to Exile, and add nominee and current count to vote messages.

### DIFF
--- a/bot_impl.py
+++ b/bot_impl.py
@@ -207,7 +207,7 @@ async def on_message(message):
                                                   "Voudon is in play. Only the Voudon and dead may vote.")
                     return
 
-                await vote.vote(vt)
+                await vote.vote(vt, voter=voting_player)
                 if global_vars.game is not game.NULL_GAME:
                     game_utils.backup("current_game.pckl")
                 return
@@ -1967,7 +1967,7 @@ async def on_message(message):
                                                       "Voudon is in play. Only the Voudon and dead may vote.")
                         return
 
-                    await vote.vote(vt, operator=message.author)
+                    await vote.vote(vt, voter=person, operator=message.author)
                     if global_vars.game is not game.NULL_GAME:
                         game_utils.backup("current_game.pckl")
                     return
@@ -1985,7 +1985,7 @@ async def on_message(message):
                                                   "Voudon is in play. Only the Voudon and dead may vote.")
                     return
 
-                await vote.vote(vt)
+                await vote.vote(vt, voter=voting_player)
                 if global_vars.game is not game.NULL_GAME:
                     game_utils.backup("current_game.pckl")
                 return

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -6,7 +6,7 @@ game state, channels, and settings.
 """
 
 from .channels import ChannelManager
-from .game import Game, NULL_GAME, Day, Vote, WhisperMode
+from .game import Game, NULL_GAME, Day, Vote, TravelerVote, WhisperMode
 # Import core model classes
 from .player import Player, STORYTELLER_ALIGNMENT
 from .settings import GameSettings, GlobalSettings
@@ -21,6 +21,7 @@ __all__ = [
     'NULL_GAME',
     'Day',
     'Vote',
+    'TravelerVote',
     'WhisperMode',
 
     # Channel management

--- a/model/game/base_vote.py
+++ b/model/game/base_vote.py
@@ -240,25 +240,26 @@ class BaseVote(ABC):
             self.votes += self.values[voter][vt]
             if vt == 1:
                 self.voted.append(voter)
+        # end critical section with vote lock
 
-            # Announcement
-            text = "yes" if vt == 1 else "no"
-            self.announcements.append(
-                (
-                    await message_utils.safe_send(
-                        global_vars.channel,
-                        f"{voter.display_name} votes {text}. {str(self.votes)} votes.",
-                    )
-                ).id
-            )
-            await (await global_vars.channel.fetch_message(self.announcements[-1])).pin()
+        # Announcement
+        text = "yes" if vt == 1 else "no"
+        self.announcements.append(
+            (
+                await message_utils.safe_send(
+                    global_vars.channel,
+                    f"{voter.display_name} votes {text}. {str(self.votes)} votes.",
+                )
+            ).id
+        )
+        await (await global_vars.channel.fetch_message(self.announcements[-1])).pin()
 
-            # Next vote
-            self.position += 1
-            if self.position == len(self.order):
-                await self.end_vote()
-                return
-            await self.call_next()
+        # Next vote
+        self.position += 1
+        if self.position == len(self.order):
+            await self.end_vote()
+            return
+        await self.call_next()
 
     async def end_vote(self) -> None:
         """When the vote is over."""

--- a/model/game/base_vote.py
+++ b/model/game/base_vote.py
@@ -1,0 +1,374 @@
+import asyncio
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Optional
+
+import discord
+
+import global_vars
+import model.settings
+from utils import message_utils, player_utils
+
+
+class VoteOutcome(Enum):
+    """Possible outcomes of a vote."""
+    PASS = "PASS"
+    TIE = "TIE"
+    FAIL = "FAIL"
+
+
+class BaseVote(ABC):
+    """Base class for voting systems with shared logic.
+
+    Attributes:
+        nominee: The player being nominated
+        nominator: The player making the nomination
+        order: The order of players voting
+        votes: The number of votes
+        voted: The players who voted
+        history: The voting history
+        announcements: The announcement messages
+        presetVotes: The preset votes
+        values: The vote weights for each player, tuple of (no votes, yes votes)
+        majority: The number of votes needed for a majority
+        position: The current position in the vote order
+        done: Whether the vote is done
+    """
+
+    # Type annotations for instance attributes
+    nominee: Optional[model.player.Player]
+    nominator: Optional[model.player.Player]
+    order: list[model.player.Player]
+    votes: int
+    voted: list[model.player.Player]
+    history: list[int]
+    announcements: list[int]
+    presetVotes: dict[int, int]
+    values: dict[model.player.Player, tuple[int, int]]
+    majority: int
+    position: int
+    done: bool
+
+    def __init__(self, nominee: Optional[model.player.Player], nominator: Optional[model.player.Player]) -> None:
+        """Initialize a BaseVote.
+
+        Args:
+            nominee: The player being nominated
+            nominator: The player making the nomination
+        """
+        self.nominee = nominee
+        self.nominator = nominator
+        self.order = self._get_voting_order()
+        self.votes = 0
+        self.voted = []
+        self.history = []
+        self.announcements = []
+        self.presetVotes = {}
+        self.values = {person: (0, 1) for person in self.order}
+        self.majority = self._calculate_majority()
+        self.position = 0
+        self.done = False
+
+    # Abstract methods (must be implemented by subclasses)
+    @abstractmethod
+    def _get_voting_order(self) -> list[model.player.Player]:
+        """Get the order of players for voting."""
+        pass
+
+    @abstractmethod
+    def _calculate_majority(self) -> int:
+        """Calculate the majority needed for this vote type."""
+        pass
+
+    @abstractmethod
+    def _determine_outcome(self) -> VoteOutcome:
+        """Determine the outcome of the vote.
+
+        Returns:
+            VoteOutcome: The outcome of the vote
+        """
+        pass
+
+    @abstractmethod
+    def _get_outcome_message(self, outcome: VoteOutcome) -> str:
+        """Get the message for a given vote outcome.
+
+        Args:
+            outcome: The vote outcome
+
+        Returns:
+            str: Message describing the outcome
+        """
+        pass
+
+    # Hook methods (can be overridden by subclasses)
+    async def _apply_outcome_effects(self, outcome: VoteOutcome) -> None:
+        """Apply side effects based on vote outcome. Override in subclasses if needed."""
+        pass
+
+    def _cleanup_player_state(self) -> None:
+        """Clean up player state after vote. Override in subclasses if needed."""
+        pass
+
+    def _validate_vote(self, voter: model.player.Player, vt: int) -> tuple[bool, str]:
+        """Validate if a vote is allowed.
+
+        Args:
+            voter: The player voting
+            vt: The vote weight (0 or 1)
+
+        Returns:
+            tuple: (allowed: bool, reason: str)
+        """
+        return True, ""
+
+    def _apply_vote_effects(self, voter: model.player.Player, vt: int) -> None:
+        """Apply any special effects when a vote is cast.
+
+        Args:
+            voter: The player voting
+            vt: The vote weight (0 or 1)
+        """
+        # Manage hand state based on vote
+        if vt == 1:  # Yes vote
+            voter.hand_raised = True
+        else:  # No vote
+            voter.hand_raised = False
+        voter.hand_locked_for_vote = True
+
+        # Update seating order message immediately
+        asyncio.create_task(global_vars.game.update_seating_order_message())
+
+    def _should_skip_voter(self, voter: model.player.Player) -> bool:
+        """Check if a player should be skipped (not asked to vote).
+
+        Args:
+            voter: The player to check
+
+        Returns:
+            bool: True if the player should be skipped
+        """
+        return False
+
+    # Core voting workflow methods
+    async def call_next(self) -> None:
+        """Calls for person to vote."""
+        to_call_player = self.order[self.position]
+        to_call_display_name = to_call_player.display_name
+        to_call_user = to_call_player.user
+        to_call_user_id = to_call_player.user.id
+        nominee_name = player_utils.get_player_display_name(self.nominee)
+
+        # Check for preset votes
+        if to_call_user_id in self.presetVotes:
+            preset_player_vote = self.presetVotes[to_call_user_id]
+            self.presetVotes[to_call_user_id] -= 1
+            await self.vote(int(preset_player_vote > 0))
+            return
+
+        # Check if player should be skipped
+        if self._should_skip_voter(to_call_player):
+            await self.vote(0)
+            return
+
+        # Call for manual vote
+        await message_utils.safe_send(global_vars.channel,
+                                      f"{to_call_user.mention}, your vote on {nominee_name}. Current votes: {self.votes}.")
+
+        # Handle default votes
+        global_settings: model.settings.GlobalSettings = model.settings.GlobalSettings.load()
+        default: Optional[tuple[int, int]] = global_settings.get_default_vote(to_call_user_id)
+        if default:
+            time = default[1]
+            yes_no = ["no", "yes"][default[0]]
+            mins = str(time // 60)
+            await message_utils.safe_send(to_call_user, f"Will enter a {yes_no} vote in {mins} minutes.")
+            await message_utils.notify_storytellers(
+                f"{to_call_display_name}'s vote on {nominee_name}. Their default is {yes_no} in {mins} minutes. Current votes: {self.votes}.")
+            await asyncio.sleep(time)
+            this_nomination = global_vars.game.days[-1].votes[-1]
+            if to_call_player == this_nomination.order[this_nomination.position]:
+                # Place default vote if still this player's turn
+                await self.vote(default[0])
+        else:
+            await message_utils.notify_storytellers(
+                f"{to_call_display_name}'s vote on {nominee_name}. They have no default. Current votes: {self.votes}.")
+
+    # TODO: Add a lock around this to prevent race conditions.  Will need to pass in expected voter.
+    async def vote(self, vt: int, operator: Optional[discord.Member] = None) -> None:
+        """Executes a vote.
+
+        Args:
+            vt: 0 if no, 1 if yes
+            operator: The operator making the vote
+        """
+        voter = self.order[self.position]
+
+        # Validate the vote
+        allowed, reason = self._validate_vote(voter, vt)
+        if not allowed:
+            if not operator:
+                await message_utils.safe_send(voter.user, reason)
+            else:
+                await message_utils.safe_send(operator, reason)
+            return
+
+        # Apply vote effects
+        self._apply_vote_effects(voter, vt)
+
+        # Vote tracking
+        self.history.append(vt)
+        self.votes += self.values[voter][vt]
+        if vt == 1:
+            self.voted.append(voter)
+
+        # Announcement
+        text = "yes" if vt == 1 else "no"
+        self.announcements.append(
+            (
+                await message_utils.safe_send(
+                    global_vars.channel,
+                    f"{voter.display_name} votes {text}. {str(self.votes)} votes.",
+                )
+            ).id
+        )
+        await (await global_vars.channel.fetch_message(self.announcements[-1])).pin()
+
+        # Next vote
+        self.position += 1
+        if self.position == len(self.order):
+            await self.end_vote()
+            return
+        await self.call_next()
+
+    async def end_vote(self) -> None:
+        """When the vote is over."""
+        # Format voter list
+        voters_text = self._format_voters_list()
+
+        # Determine outcome and apply effects
+        outcome = self._determine_outcome()
+        await self._apply_outcome_effects(outcome)
+
+        # Send announcement
+        message = self._get_outcome_message(outcome)
+        await self._send_final_announcement(voters_text, message)
+
+        # Clean up all vote state
+        await self._cleanup_vote_state()
+
+        # Finalize and reopen game interactions
+        await self._finalize_vote()
+
+    # Helper methods for end_vote
+    def _format_voters_list(self) -> str:
+        """Format the list of voters into a readable string."""
+        the_voters = list(dict.fromkeys(self.voted))  # Remove duplicates while preserving order
+
+        if len(the_voters) == 0:
+            return "no one"
+        elif len(the_voters) == 1:
+            return the_voters[0].display_name
+        elif len(the_voters) == 2:
+            return f"{the_voters[0].display_name} and {the_voters[1].display_name}"
+        else:
+            names = ", ".join(voter.display_name for voter in the_voters[:-1])
+            return f"{names}, and {the_voters[-1].display_name}"
+
+    async def _send_final_announcement(self, voters_text: str, outcome_message: str) -> discord.Message:
+        """Send the final vote announcement and pin it."""
+        nominee_name = player_utils.get_player_display_name(self.nominee)
+        nominator_name = player_utils.get_player_display_name(self.nominator)
+
+        message_suffix = f". {outcome_message}" if outcome_message else "."
+
+        announcement = await message_utils.safe_send(
+            global_vars.channel,
+            f"{self.votes} votes on {nominee_name} (nominated by {nominator_name}): {voters_text}{message_suffix}"
+        )
+
+        await announcement.pin()
+        global_vars.game.days[-1].voteEndMessages.append(announcement.id)
+        return announcement
+
+    async def _cleanup_vote_messages(self) -> None:
+        """Unpin individual vote messages."""
+        for msg_id in self.announcements:
+            try:
+                message = await global_vars.channel.fetch_message(msg_id)
+                await message.unpin()
+            except discord.errors.NotFound:
+                print("Missing message: ", str(msg_id))
+            except discord.errors.DiscordServerError:
+                print("Discord server error: ", str(msg_id))
+
+    async def _reset_player_hands(self) -> None:
+        """Reset hand states for all players and update seating order display."""
+        for person in global_vars.game.seatingOrder:
+            person.hand_raised = False
+            person.hand_locked_for_vote = False
+
+        # Update seating order message to reflect hand state changes
+        await global_vars.game.update_seating_order_message()
+
+    async def _cleanup_vote_state(self) -> None:
+        """Clean up all per-nomination state after voting concludes."""
+        # Clean up vote messages
+        await self._cleanup_vote_messages()
+
+        # Reset player hands
+        await self._reset_player_hands()
+
+        # Additional cleanup in subclasses
+        self._cleanup_player_state()
+
+    async def _finalize_vote(self) -> None:
+        """Finalize vote state and reopen game interactions."""
+        self.done = True
+        await global_vars.game.days[-1].open_noms()
+        await global_vars.game.days[-1].open_pms()
+
+    # Vote management methods
+    async def preset_vote(self, person: model.player.Player, vt: int,
+                          operator: Optional[discord.Member] = None) -> None:
+        """Preset a vote.
+
+        Args:
+            person: The player to preset
+            vt: The vote value
+            operator: The operator making the preset
+        """
+        # Validate the preset vote
+        allowed, reason = self._validate_vote(person, vt)
+        if not allowed:
+            if not operator:
+                await message_utils.safe_send(person.user, reason)
+            else:
+                await message_utils.safe_send(operator, reason)
+            return
+
+        self.presetVotes[person.user.id] = vt
+
+    async def cancel_preset(self, person: model.player.Player) -> None:
+        """Cancel a preset vote.
+
+        Args:
+            person: The player to cancel the preset for
+        """
+        if person.user.id in self.presetVotes:
+            del self.presetVotes[person.user.id]
+
+    async def delete(self) -> None:
+        """Undoes an unintentional nomination."""
+        if self.nominator:
+            self.nominator.can_nominate = True
+        if self.nominee:
+            self.nominee.can_be_nominated = True
+
+        for msg in self.announcements:
+            try:
+                await (await global_vars.channel.fetch_message(msg)).unpin()
+            except discord.errors.NotFound:
+                pass
+        self.done = True
+        global_vars.game.days[-1].votes.remove(self)

--- a/model/game/traveler_vote.py
+++ b/model/game/traveler_vote.py
@@ -1,206 +1,31 @@
-import asyncio
-
-import discord
+import math
 
 import global_vars
-import model.settings
-from utils import message_utils
+import model
+from model.game.base_vote import BaseVote, VoteOutcome
 
 
-class TravelerVote:
+class TravelerVote(BaseVote):
     """Stores information about a specific call for exile.
 
-    Attributes:
-        nominee: The player being nominated
-        nominator: The player making the nomination
-        order: The order of players voting
-        votes: The number of votes
-        voted: The players who voted
-        history: The voting history
-        announcements: The announcement messages
-        presetVotes: The preset votes
-        values: The vote values for each player
-        majority: The number of votes needed for a majority
-        position: The current position in the vote order
-        done: Whether the vote is done
+    Inherits all attributes from BaseVote. See BaseVote for detailed attribute documentation.
     """
 
-    def __init__(self, nominee, nominator):
-        """Initialize a TravelerVote.
+    # Abstract method implementations
+    def _get_voting_order(self) -> list[model.player.Player]:
+        """Get the order of players for voting."""
+        seating_order = global_vars.game.seatingOrder
+        nominee_index = seating_order.index(self.nominee)
+        return seating_order[nominee_index + 1:] + seating_order[:nominee_index + 1]
 
-        Args:
-            nominee: The player being nominated
-            nominator: The player making the nomination
-        """
-        self.nominee = nominee
-        self.nominator = nominator
-        self.order = (
-                global_vars.game.seatingOrder[global_vars.game.seatingOrder.index(self.nominee) + 1:]
-                + global_vars.game.seatingOrder[: global_vars.game.seatingOrder.index(self.nominee) + 1]
-        )
-        self.votes = 0
-        self.voted = []
-        self.history = []
-        self.announcements = []
-        self.presetVotes = {}
-        self.values = {person: (0, 1) for person in self.order}
-        self.majority = len(self.order) / 2
-        self.position = 0
-        self.done = False
+    def _calculate_majority(self) -> int:
+        """Calculate the majority needed for this vote type."""
+        return math.ceil(len(self.order) / 2)
 
-    async def call_next(self):
-        """Calls for person to vote."""
-        toCall = self.order[self.position]
-        if toCall.user.id in self.presetVotes:
-            await self.vote(self.presetVotes[toCall.user.id])
-            return
-        await message_utils.safe_send(
-            global_vars.channel,
-            "{}, your vote on {}.".format(
-                toCall.user.mention,
-                self.nominee.display_name if self.nominee else "the storytellers",
-            ),
-        )
-        global_settings: model.settings.GlobalSettings = model.settings.GlobalSettings.load()
-        default = global_settings.get_default_vote(toCall.user.id)
-        if default:
-            time = default[1]
-            await message_utils.safe_send(toCall.user, "Will enter a {} vote in {} minutes.".format(
-                ["no", "yes"][default[0]], str(int(default[1] / 60))
-            ))
-            await asyncio.sleep(time)
-            if toCall == global_vars.game.days[-1].votes[-1].order[global_vars.game.days[-1].votes[-1].position]:
-                await self.vote(default[0])
-            for memb in global_vars.gamemaster_role.members:
-                await message_utils.safe_send(
-                    memb,
-                    "{}'s vote. Their default is {} in {} minutes.".format(
-                        toCall.display_name,
-                        ["no", "yes"][default[0]],
-                        str(int(default[1] / 60)),
-                    ),
-                )
-        else:
-            for memb in global_vars.gamemaster_role.members:
-                await message_utils.safe_send(
-                    memb, "{}'s vote. They have no default.".format(toCall.display_name)
-                )
+    def _determine_outcome(self) -> VoteOutcome:
+        """Determine the outcome of the vote."""
+        return VoteOutcome.PASS if self.votes >= self.majority else VoteOutcome.FAIL
 
-    async def vote(self, vt, operator=None):
-        """Executes a vote.
-
-        Args:
-            vt: 0 if no, 1 if yes
-            operator: The operator making the vote
-        """
-        # Voter
-        voter = self.order[self.position]
-
-        # Vote tracking
-        self.history.append(vt)
-        self.votes += self.values[voter][vt]
-        if vt == 1:
-            self.voted.append(voter)
-
-        # Announcement
-        text = "yes" if vt == 1 else "no"
-        self.announcements.append(
-            (
-                await message_utils.safe_send(
-                    global_vars.channel,
-                    "{} votes {}. {} votes.".format(voter.display_name, text, str(self.votes)),
-                )
-            ).id
-        )
-        await (await global_vars.channel.fetch_message(self.announcements[-1])).pin()
-
-        # Next vote
-        self.position += 1
-        if self.position == len(self.order):
-            await self.end_vote()
-            return
-        await self.call_next()
-
-    async def end_vote(self):
-        """When the vote is over."""
-        if len(self.voted) == 0:
-            text = "no one"
-        elif len(self.voted) == 1:
-            text = self.voted[0].display_name
-        elif len(self.voted) == 2:
-            text = self.voted[0].display_name + " and " + self.voted[1].display_name
-        else:
-            text = (", ".join([x.display_name for x in self.voted[:-1]]) + ", and " + self.voted[-1].display_name)
-        if self.votes >= self.majority:
-            announcement = await message_utils.safe_send(
-                global_vars.channel,
-                "{} votes on {} (nominated by {}): {}.".format(
-                    str(self.votes),
-                    self.nominee.display_name if self.nominee else "the storytellers",
-                    self.nominator.display_name if self.nominator else "the storytellers",
-                    text,
-                ),
-            )
-        else:
-            announcement = await message_utils.safe_send(
-                global_vars.channel,
-                "{} votes on {} (nominated by {}): {}. They are not exiled.".format(
-                    str(self.votes),
-                    self.nominee.display_name if self.nominee else "the storytellers",
-                    self.nominator.display_name if self.nominator else "the storytellers",
-                    text,
-                ),
-            )
-
-        await announcement.pin()
-        global_vars.game.days[-1].voteEndMessages.append(announcement.id)
-
-        for msg in self.announcements:
-            try:
-                await (await global_vars.channel.fetch_message(msg)).unpin()
-            except discord.errors.NotFound:
-                print("Missing message: ", str(msg))
-            except discord.errors.DiscordServerError:
-                print("Discord server error: ", str(msg))
-
-        self.done = True
-
-        await global_vars.game.days[-1].open_noms()
-        await global_vars.game.days[-1].open_pms()
-
-    async def preset_vote(self, person, vt, operator=None):
-        """Preset a vote.
-
-        Args:
-            person: The player to preset
-            vt: The vote value
-            operator: The operator making the preset
-        """
-        self.presetVotes[person.user.id] = vt
-
-    async def cancel_preset(self, person):
-        """Cancel a preset vote.
-
-        Args:
-            person: The player to cancel the preset for
-        """
-        del self.presetVotes[person.user.id]
-
-    async def delete(self):
-        """Undoes an unintentional nomination."""
-        if self.nominator:
-            self.nominator.can_nominate = True
-        if self.nominee:
-            self.nominee.can_be_nominated = True
-
-        for msg in self.announcements:
-            try:
-                await (await global_vars.channel.fetch_message(msg)).unpin()
-            except discord.errors.NotFound:
-                print("Missing message: ", str(msg))
-            except discord.errors.DiscordServerError:
-                print("Discord server error: ", str(msg))
-
-        self.done = True
-
-        global_vars.game.days[-1].votes.remove(self)
+    def _get_outcome_message(self, outcome: VoteOutcome) -> str:
+        """Get the message for a given vote outcome."""
+        return "They are not exiled" if outcome == VoteOutcome.FAIL else ""

--- a/model/game/vote.py
+++ b/model/game/vote.py
@@ -1,15 +1,14 @@
 import asyncio
-from collections import OrderedDict
-
-import discord
+import math
+from typing import Optional
 
 import global_vars
 import model.characters
-import model.settings
-from utils import character_utils, message_utils, player_utils
+from model.game.base_vote import BaseVote, VoteOutcome
+from utils import character_utils, player_utils
 
 
-def in_play_voudon():
+def in_play_voudon() -> Optional[model.player.Player]:
     """Check if a Voudon is in play.
 
     Returns:
@@ -19,7 +18,7 @@ def in_play_voudon():
                  character_utils.the_ability(x.character, model.characters.Voudon) and not x.is_ghost), None)
 
 
-def remove_banshee_nomination(banshee_ability_of_player):
+def remove_banshee_nomination(banshee_ability_of_player) -> None:
     """Remove a nomination from a Banshee.
 
     Args:
@@ -27,354 +26,6 @@ def remove_banshee_nomination(banshee_ability_of_player):
     """
     if banshee_ability_of_player and banshee_ability_of_player.is_screaming:
         banshee_ability_of_player.remaining_nominations -= 1
-
-
-class Vote:
-    """Stores information about a specific vote.
-    
-    Attributes:
-        nominee: The player being nominated
-        nominator: The player making the nomination
-        order: The order of players voting
-        votes: The number of votes
-        voted: The players who voted
-        history: The voting history
-        announcements: The announcement messages
-        presetVotes: The preset votes
-        values: The vote values for each player
-        majority: The number of votes needed for a majority
-        position: The current position in the vote order
-        done: Whether the vote is done
-    """
-
-    def __init__(self, nominee, nominator):
-        """Initialize a Vote.
-        
-        Args:
-            nominee: The player being nominated
-            nominator: The player making the nomination
-        """
-        self.nominee = nominee
-        self.nominator = nominator
-        if self.nominee is not None:
-            ordered_voters = (
-                    global_vars.game.seatingOrder[global_vars.game.seatingOrder.index(self.nominee) + 1:]
-                    + global_vars.game.seatingOrder[: global_vars.game.seatingOrder.index(self.nominee) + 1]
-            )
-        else:
-            ordered_voters = global_vars.game.seatingOrder
-        # augment order with Banshees
-        order_with_banshees = []
-        for person in ordered_voters:
-            order_with_banshees.append(person)
-            banshee_ability = character_utils.the_ability(person.character, model.characters.Banshee)
-            if banshee_ability and banshee_ability.is_screaming:
-                order_with_banshees.append(person)
-
-        self.order = order_with_banshees
-
-        self.votes = 0
-        self.voted = []
-        self.history = []
-        self.announcements = []
-        self.presetVotes = {}
-        self.values = {person: (0, 1) for person in self.order}
-        self.majority = 0.0
-        for person in self.order:
-            if not person.is_ghost:
-                self.majority += 0.5
-        for person in global_vars.game.seatingOrder:
-            if isinstance(person.character, model.characters.VoteBeginningModifier):
-                (
-                    self.order,
-                    self.values,
-                    self.majority,
-                ) = person.character.modify_vote_values(
-                    self.order, self.values, self.majority
-                )
-        self.position = 0
-        self.done = False
-
-    async def call_next(self):
-        """Calls for person to vote."""
-        toCall = self.order[self.position]
-        player_banshee_ability = character_utils.the_ability(toCall.character, model.characters.Banshee)
-        player_is_active_banshee = player_banshee_ability and player_banshee_ability.is_screaming
-        voudon_is_active = in_play_voudon()
-        for person in global_vars.game.seatingOrder:
-            if isinstance(person.character, model.characters.VoteModifier):
-                person.character.on_vote_call(toCall)
-        if toCall.is_ghost and toCall.dead_votes < 1 and not player_is_active_banshee and not voudon_is_active:
-            await self.vote(0)
-            return
-        if toCall.user.id in self.presetVotes:
-            preset_player_vote = self.presetVotes[toCall.user.id]
-            self.presetVotes[toCall.user.id] -= 1
-            await self.vote(int(preset_player_vote > 0))
-            return
-        await message_utils.safe_send(
-            global_vars.channel,
-            "{}, your vote on {}.".format(
-                toCall.user.mention,
-                self.nominee.display_name if self.nominee else "the storytellers",
-            ),
-        )
-        global_settings: model.settings.GlobalSettings = model.settings.GlobalSettings.load()
-        default = global_settings.get_default_vote(toCall.user.id)
-        if default:
-            time = default[1]
-            await message_utils.safe_send(toCall.user, "Will enter a {} vote in {} minutes.".format(
-                ["no", "yes"][default[0]], str(int(default[1] / 60))
-            ))
-            for memb in global_vars.gamemaster_role.members:
-                await message_utils.safe_send(
-                    memb,
-                    "{}'s vote. Their default is {} in {} minutes.".format(
-                        toCall.display_name,
-                        ["no", "yes"][default[0]],
-                        str(int(default[1] / 60)),
-                    ),
-                )
-            await asyncio.sleep(time)
-            if toCall == global_vars.game.days[-1].votes[-1].order[global_vars.game.days[-1].votes[-1].position]:
-                await self.vote(default[0])
-        else:
-            for memb in global_vars.gamemaster_role.members:
-                await message_utils.safe_send(
-                    memb, "{}'s vote. They have no default.".format(toCall.display_name)
-                )
-
-    async def vote(self, vt, operator=None):
-        """Executes a vote.
-        
-        Args:
-            vt: 0 if no, 1 if yes
-            operator: The operator making the vote
-        """
-        # Voter
-        voter = self.order[self.position]
-
-        # Manage hand state based on vote
-        if vt == 1:  # Yes vote
-            voter.hand_raised = True
-        else:  # No vote
-            voter.hand_raised = False
-        voter.hand_locked_for_vote = True
-
-        # Update seating order message immediately
-        await global_vars.game.update_seating_order_message()
-
-        potential_banshee = character_utils.the_ability(voter.character, model.characters.Banshee)
-
-        # see if a Voudon is in play
-        voudon_in_play = in_play_voudon()
-        player_is_active_banshee = potential_banshee and voter.character.is_screaming
-        # Check dead votes
-        if vt == 1 and voter.is_ghost and voter.dead_votes < 1 and not (
-                player_is_active_banshee and not potential_banshee.is_poisoned) and not voudon_in_play:
-            if not operator:
-                await message_utils.safe_send(voter.user, "You do not have any dead votes. Entering a no vote.")
-                await self.vote(0)
-            else:
-                await message_utils.safe_send(
-                    operator,
-                    "{} does not have any dead votes. They must vote no. If you want them to vote yes, add a dead vote first:\n```\n@givedeadvote [player]\n```".format(
-                        voter.display_name
-                    ),
-                )
-            return
-        if vt == 1 and voter.is_ghost and not (
-                player_is_active_banshee and not potential_banshee.is_poisoned) and not voudon_in_play:
-            await voter.remove_dead_vote()
-
-        # On vote character powers
-        for person in global_vars.game.seatingOrder:
-            if isinstance(person.character, model.characters.VoteModifier):
-                person.character.on_vote()
-
-        # Vote tracking
-        self.history.append(vt)
-        self.votes += self.values[voter][vt]
-        if vt == 1:
-            self.voted.append(voter)
-
-        # Announcement
-        text = "yes" if vt == 1 else "no"
-        self.announcements.append(
-            (
-                await message_utils.safe_send(
-                    global_vars.channel,
-                    "{} votes {}. {} votes.".format(voter.display_name, text, str(self.votes)),
-                )
-            ).id
-        )
-        await (await global_vars.channel.fetch_message(self.announcements[-1])).pin()
-
-        # Next vote
-        self.position += 1
-        if self.position == len(self.order):
-            await self.end_vote()
-            return
-        await self.call_next()
-
-    async def end_vote(self):
-        """When the vote is over."""
-        tie = False
-        aboutToDie = global_vars.game.days[-1].aboutToDie
-        if self.votes >= self.majority:
-            if aboutToDie is None:
-                dies = True
-            elif self.votes > aboutToDie[1].votes:
-                dies = True
-            elif self.votes == aboutToDie[1].votes:
-                dies = False
-                tie = True
-            else:
-                dies = False
-        else:
-            dies = False
-        for person in global_vars.game.seatingOrder:
-            if isinstance(person.character, model.characters.VoteModifier):
-                dies, tie = person.character.on_vote_conclusion(dies, tie)
-        for person in global_vars.game.seatingOrder:
-            person.riot_nominee = False
-        the_voters = self.voted
-        # remove duplicate voters
-        the_voters = list(OrderedDict.fromkeys(the_voters))
-        if len(the_voters) == 0:
-            text = "no one"
-        elif len(the_voters) == 1:
-            text = the_voters[0].display_name
-        elif len(the_voters) == 2:
-            text = the_voters[0].display_name + " and " + the_voters[1].display_name
-        else:
-            text = (", ".join([x.display_name for x in the_voters[:-1]]) + ", and " + the_voters[-1].display_name)
-        if dies:
-            if aboutToDie is not None and aboutToDie[0] is not None:
-                msg = await global_vars.channel.fetch_message(
-                    global_vars.game.days[-1].voteEndMessages[
-                        global_vars.game.days[-1].votes.index(aboutToDie[1])
-                    ]
-                )
-                await msg.edit(
-                    content=msg.content[:-31] + " They are not about to be executed."
-                )
-            global_vars.game.days[-1].aboutToDie = (self.nominee, self)
-            announcement = await message_utils.safe_send(
-                global_vars.channel,
-                "{} votes on {} (nominated by {}): {}. They are about to be executed.".format(
-                    str(self.votes),
-                    self.nominee.display_name if self.nominee else "the storytellers",
-                    self.nominator.display_name if self.nominator else "the storytellers",
-                    text,
-                ),
-            )
-        elif tie:
-            if aboutToDie is not None:
-                msg = await global_vars.channel.fetch_message(
-                    global_vars.game.days[-1].voteEndMessages[
-                        global_vars.game.days[-1].votes.index(aboutToDie[1])
-                    ]
-                )
-                await msg.edit(
-                    content=msg.content[:-31] + " No one is about to be executed."
-                )
-            global_vars.game.days[-1].aboutToDie = (None, self)
-            announcement = await message_utils.safe_send(
-                global_vars.channel,
-                "{} votes on {} (nominated by {}): {}. No one is about to be executed.".format(
-                    str(self.votes),
-                    self.nominee.display_name if self.nominee else "the storytellers",
-                    self.nominator.display_name if self.nominator else "the storytellers",
-                    text,
-                ),
-            )
-        else:
-            announcement = await message_utils.safe_send(
-                global_vars.channel,
-                "{} votes on {} (nominated by {}): {}. They are not about to be executed.".format(
-                    str(self.votes),
-                    self.nominee.display_name if self.nominee else "the storytellers",
-                    self.nominator.display_name if self.nominator else "the storytellers",
-                    text,
-                ),
-            )
-
-        await announcement.pin()
-        global_vars.game.days[-1].voteEndMessages.append(announcement.id)
-
-        for msg in self.announcements:
-            try:
-                await (await global_vars.channel.fetch_message(msg)).unpin()
-            except discord.errors.NotFound:
-                print("Missing message: ", str(msg))
-            except discord.errors.DiscordServerError:
-                print("Discord server error: ", str(msg))
-
-        # Lower all hands and reset vote lock
-        for person in global_vars.game.seatingOrder:
-            person.hand_raised = False
-            person.hand_locked_for_vote = False
-
-        # Update seating order message
-        await global_vars.game.update_seating_order_message()
-
-        self.done = True
-
-        await global_vars.game.days[-1].open_noms()
-        await global_vars.game.days[-1].open_pms()
-
-    async def preset_vote(self, person, vt, operator=None):
-        """Preset a vote.
-
-        Args:
-            person: The player to preset
-            vt: The vote value
-            operator: The operator making the preset
-        """
-        # Check dead votes
-        banshee_ability = character_utils.the_ability(person.character, model.characters.Banshee)
-        banshee_override = banshee_ability and banshee_ability.is_screaming
-        if vt > 0 and person.is_ghost and person.dead_votes < 1 and not banshee_override:
-            if not operator:
-                await message_utils.safe_send(person.user, "You do not have any dead votes. Please vote no.")
-            else:
-                await message_utils.safe_send(
-                    operator,
-                    "{} does not have any dead votes. They must vote no.".format(
-                        person.display_name
-                    ),
-                )
-            return
-
-        self.presetVotes[person.user.id] = vt
-
-    async def cancel_preset(self, person):
-        """Cancel a preset vote.
-
-        Args:
-            person: The player to cancel the preset for
-        """
-        if (person.user.id in self.presetVotes):
-            del self.presetVotes[person.user.id]
-
-    async def delete(self):
-        """Undoes an unintentional nomination."""
-        if self.nominator:
-            self.nominator.can_nominate = True
-        if self.nominee:
-            self.nominee.can_be_nominated = True
-
-        for msg in self.announcements:
-            try:
-                await (await global_vars.channel.fetch_message(msg)).unpin()
-            except discord.errors.NotFound:
-                pass
-        self.done = True
-        global_vars.game.days[-1].votes.remove(self)
-
-
-# Removed: _generate_member_possibilities is now replaced with direct import
 
 
 async def is_storyteller(arg, member_possibilities_fn=None, server_members=None, server=None, gamemaster_role=None):
@@ -421,3 +72,162 @@ async def is_storyteller(arg, member_possibilities_fn=None, server_members=None,
 
     # Check if the member has the gamemaster role
     return _gamemaster_role in member.roles
+
+
+class Vote(BaseVote):
+    """Stores information about a specific vote.
+    
+    Inherits all attributes from BaseVote. See BaseVote for detailed attribute documentation.
+    """
+
+    def __init__(self, nominee, nominator):
+        """Initialize a Vote.
+        
+        Args:
+            nominee: The player being nominated
+            nominator: The player making the nomination
+        """
+        super().__init__(nominee, nominator)
+
+        # Apply vote beginning modifiers
+        for person in global_vars.game.seatingOrder:
+            if isinstance(person.character, model.characters.VoteBeginningModifier):
+                (
+                    self.order,
+                    self.values,
+                    self.majority,
+                ) = person.character.modify_vote_values(
+                    self.order, self.values, self.majority
+                )
+
+    # Abstract method implementations
+    def _get_voting_order(self) -> list['model.player.Player']:
+        """Get the order of players for voting."""
+        seating_order = global_vars.game.seatingOrder
+        # When nominating the storyteller, just use the seating order
+        if self.nominee is None:
+            ordered_voters = seating_order
+        else:
+            nominee_index = seating_order.index(self.nominee)
+            ordered_voters = seating_order[nominee_index + 1:] + seating_order[: nominee_index + 1]
+
+        # augment order with Banshees
+        order_with_banshees = []
+        for person in ordered_voters:
+            order_with_banshees.append(person)
+            banshee_ability = character_utils.the_ability(person.character, model.characters.Banshee)
+            if banshee_ability and banshee_ability.is_screaming:
+                order_with_banshees.append(person)
+
+        return order_with_banshees
+
+    def _calculate_majority(self) -> int:
+        """Calculate the majority needed for this vote type."""
+        living_voters = [person for person in self.order if not person.is_ghost]
+        return math.ceil(len(living_voters) / 2)
+
+    def _determine_outcome(self) -> VoteOutcome:
+        """Determine the outcome of the vote (pure logic only)."""
+        about_to_die: Optional[tuple[Optional[model.player.Player], BaseVote]] = global_vars.game.days[-1].aboutToDie
+        dies = tie = False
+
+        if self.votes >= self.majority:
+            if about_to_die is None or self.votes > about_to_die[1].votes:
+                dies = True
+            elif self.votes == about_to_die[1].votes:
+                tie = True
+
+        # TODO: Consider removing this logic
+        # I think we should remove this logic, it's not currently used and the fact we're just looping through
+        # all players in order means if we had more than one VoteModifier in play, the order is effectively arbitrary.
+        for person in global_vars.game.seatingOrder:
+            if isinstance(person.character, model.characters.VoteModifier):
+                dies, tie = person.character.on_vote_conclusion(dies, tie)
+
+        return VoteOutcome.PASS if dies else VoteOutcome.TIE if tie else VoteOutcome.FAIL
+
+    def _get_outcome_message(self, outcome: VoteOutcome) -> str:
+        """Get the message for a given vote outcome."""
+        outcome_messages = {
+            VoteOutcome.PASS: "They are about to be executed",
+            VoteOutcome.TIE: "No one is about to be executed",
+            VoteOutcome.FAIL: "They are not about to be executed",
+        }
+        return outcome_messages[outcome]
+
+    # Hook method overrides
+    async def _apply_outcome_effects(self, outcome: VoteOutcome) -> None:
+        """Apply side effects based on vote outcome."""
+        about_to_die: Optional[tuple[Optional[model.player.Player], BaseVote]] = global_vars.game.days[-1].aboutToDie
+
+        if outcome == VoteOutcome.PASS:
+            if about_to_die is not None and about_to_die[0] is not None:
+                await self._update_previous_about_to_die_message(" They are not about to be executed.")
+            global_vars.game.days[-1].aboutToDie = (self.nominee, self)
+        elif outcome == VoteOutcome.TIE:
+            if about_to_die is not None:
+                await self._update_previous_about_to_die_message(" No one is about to be executed.")
+            # If the vote is a tie, we track this vote for the aboutToDie count threshold but not the nominee
+            global_vars.game.days[-1].aboutToDie = (None, self)
+
+    def _cleanup_player_state(self) -> None:
+        """Clean up riot nominee state for all players."""
+        for person in global_vars.game.seatingOrder:
+            person.riot_nominee = False
+
+    def _validate_vote(self, voter: 'model.player.Player', vt: int) -> tuple[bool, str]:
+        """Validate if a vote is allowed."""
+        potential_banshee = character_utils.the_ability(voter.character, model.characters.Banshee)
+        voudon_in_play = in_play_voudon()
+        player_is_active_banshee = potential_banshee and potential_banshee.is_screaming
+
+        # Check dead votes
+        if vt == 1 and voter.is_ghost and voter.dead_votes < 1 and not (
+                player_is_active_banshee and not potential_banshee.is_poisoned) and not voudon_in_play:
+            return False, "You do not have any dead votes. Entering a no vote."
+
+        return True, ""
+
+    def _apply_vote_effects(self, voter: 'model.player.Player', vt: int) -> None:
+        """Apply any special effects when a vote is cast."""
+        # Call parent to handle hand state and seating order update
+        super()._apply_vote_effects(voter, vt)
+
+        potential_banshee = character_utils.the_ability(voter.character, model.characters.Banshee)
+        voudon_in_play = in_play_voudon()
+        player_is_active_banshee = potential_banshee and potential_banshee.is_screaming
+
+        # Use dead vote if applicable
+        if vt == 1 and voter.is_ghost and not (
+                player_is_active_banshee and not potential_banshee.is_poisoned) and not voudon_in_play:
+            asyncio.create_task(voter.remove_dead_vote())
+
+        # On vote character powers
+        for person in global_vars.game.seatingOrder:
+            if isinstance(person.character, model.characters.VoteModifier):
+                person.character.on_vote()
+
+    def _should_skip_voter(self, voter: 'model.player.Player') -> bool:
+        """Check if a player should be skipped (not asked to vote)."""
+        player_banshee_ability = character_utils.the_ability(voter.character, model.characters.Banshee)
+        player_is_active_banshee = player_banshee_ability and player_banshee_ability.is_screaming
+        voudon_is_active = in_play_voudon()
+
+        # Call vote modifiers
+        for person in global_vars.game.seatingOrder:
+            if isinstance(person.character, model.characters.VoteModifier):
+                person.character.on_vote_call(voter)
+
+        # Skip ghosts without dead votes (unless they have special abilities)
+        return voter.is_ghost and voter.dead_votes < 1 and not player_is_active_banshee and not voudon_is_active
+
+    # Helper methods
+    async def _update_previous_about_to_die_message(self, suffix: str) -> None:
+        """Update the previous about to die message."""
+        about_to_die_nom: BaseVote = global_vars.game.days[-1].aboutToDie[1]
+        msg = await global_vars.channel.fetch_message(
+            global_vars.game.days[-1].voteEndMessages[
+                global_vars.game.days[-1].votes.index(about_to_die_nom)
+            ]
+        )
+        await msg.edit(content=msg.content[:-31] + suffix)

--- a/tests/commands/test_player_commands.py
+++ b/tests/commands/test_player_commands.py
@@ -62,7 +62,7 @@ async def test_player_vote_command(mock_discord_setup, setup_test_game):
         )
 
         # Verify vote was called with 1 (yes)
-        vote_mock.assert_called_once_with(1)
+        vote_mock.assert_called_once_with(1, voter=alice)
 
     # Reset the vote state for the next test
     vote.position = 0
@@ -80,7 +80,7 @@ async def test_player_vote_command(mock_discord_setup, setup_test_game):
         )
 
         # Verify vote was called with 0 (no)
-        vote_mock.assert_called_once_with(0)
+        vote_mock.assert_called_once_with(0, voter=alice)
 
 
 @pytest.mark.asyncio

--- a/tests/discord/test_command_interactions.py
+++ b/tests/discord/test_command_interactions.py
@@ -160,17 +160,17 @@ async def test_voting_sequence_with_execution(mock_discord_setup, setup_test_gam
                     vote.vote = AsyncMock()
 
                     # Add a side effect to simulate voter advancing
-                    async def vote_side_effect(vote_val):
+                    async def vote_side_effect(vote_val, voter=None):
                         vote.position = 1  # Move to Bob
                         return vote_val
 
                     vote.vote.side_effect = vote_side_effect
 
                     # Alice votes yes
-                    await vote.vote(1)
+                    await vote.vote(1, voter=setup_test_game['players']['alice'])
 
                     # Verify vote was called with 1 (yes)
-                    vote.vote.assert_called_once_with(1)
+                    vote.vote.assert_called_once_with(1, voter=setup_test_game['players']['alice'])
 
                     # Reset mock for next vote
                     vote.vote.reset_mock()
@@ -181,7 +181,7 @@ async def test_voting_sequence_with_execution(mock_discord_setup, setup_test_gam
             with patch('utils.game_utils.backup', return_value=None):
                 with patch('utils.message_utils.safe_send', return_value=AsyncMock()) as mock_safe_send:
                     # Add a side effect for the final vote
-                    async def final_vote_side_effect(vote_val):
+                    async def final_vote_side_effect(vote_val, voter=None):
                         vote.position = 2  # Move past all voters
                         vote.done = True  # Mark as done
 
@@ -196,10 +196,10 @@ async def test_voting_sequence_with_execution(mock_discord_setup, setup_test_gam
                     setup_test_game['players']['charlie'].kill = AsyncMock()
 
                     # Bob votes yes
-                    await vote.vote(1)
+                    await vote.vote(1, voter=setup_test_game['players']['bob'])
 
                     # Verify vote was called with 1 (yes)
-                    vote.vote.assert_called_once_with(1)
+                    vote.vote.assert_called_once_with(1, voter=setup_test_game['players']['bob'])
 
                     # In a real execution, kill would be called on the nominee
                     # To test this fully, we would need to implement kill logic in the vote side effect
@@ -890,7 +890,7 @@ async def test_on_message_handling(mock_discord_setup, setup_test_game):
                 await on_message(vote_message)
 
                 # Verify vote was called with 1 (yes)
-                vote.vote.assert_called_once_with(1)
+                vote.vote.assert_called_once_with(1, voter=setup_test_game['players']['alice'])
 
     # Restore original vote method
     vote.vote = original_vote

--- a/tests/discord/test_on_message.py
+++ b/tests/discord/test_on_message.py
@@ -308,7 +308,7 @@ async def test_on_message_vote_successful(mock_discord_setup, setup_test_game):
                 await on_message(alice_message)
 
                 # Verify vote was called with 1 (yes)
-                mock_vote.vote.assert_called_once_with(1)
+                mock_vote.vote.assert_called_once_with(1, voter=setup_test_game['players']['alice'])
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot_integration.py
+++ b/tests/test_bot_integration.py
@@ -205,7 +205,7 @@ async def test_on_message_vote_command(mock_discord_setup, setup_test_game):
             await on_message(alice_vote)
 
             # Verify that vote was called with 1 (yes)
-            vote.vote.assert_called_once_with(1)
+            vote.vote.assert_called_once_with(1, voter=setup_test_game['players']['alice'])
 
     # Restore original vote method
     vote.vote = original_vote
@@ -300,7 +300,7 @@ async def test_on_message_vote_invalid_format(mock_discord_setup, setup_test_gam
             await on_message(alice_vote_no)
 
             # Verify that vote was called with 0 (no)
-            vote.vote.assert_called_once_with(0)
+            vote.vote.assert_called_once_with(0, voter=setup_test_game['players']['alice'])
 
     # Restore original vote method
     vote.vote = original_vote
@@ -897,7 +897,7 @@ async def test_complete_voting_workflow(mock_discord_setup, setup_test_game):
 
     # Add a side effect to simulate voter advancing and vote tallying
     @pytest.mark.usefixtures("setup_test_game")
-    async def vote_side_effect(vote_val):
+    async def vote_side_effect(vote_val, voter=None):
         # Initialize vote attributes if needed
         if not hasattr(vote, 'voted'):
             vote.voted = []
@@ -920,7 +920,7 @@ async def test_complete_voting_workflow(mock_discord_setup, setup_test_game):
             await on_message(alice_vote_msg)
 
             # Verify vote was called with 1 (yes)
-            vote.vote.assert_called_once_with(1)
+            vote.vote.assert_called_once_with(1, voter=setup_test_game['players']['alice'])
 
     # Clear the mock
     vote.vote.reset_mock()
@@ -936,7 +936,7 @@ async def test_complete_voting_workflow(mock_discord_setup, setup_test_game):
 
     # Add a side effect for Bob's vote that completes the vote
     @pytest.mark.usefixtures("setup_test_game")
-    async def final_vote_side_effect(vote_val):
+    async def final_vote_side_effect(vote_val, voter=None):
         # Initialize vote attributes if needed
         if not hasattr(vote, 'voted'):
             vote.voted = []
@@ -965,7 +965,7 @@ async def test_complete_voting_workflow(mock_discord_setup, setup_test_game):
             await on_message(bob_vote_msg)
 
             # Verify vote was called with 0 (no)
-            vote.vote.assert_called_once_with(0)
+            vote.vote.assert_called_once_with(0, voter=setup_test_game['players']['bob'])
 
     # 3. Test trying to vote on a completed vote
     alice_late_vote_msg = MockMessage(
@@ -1471,7 +1471,7 @@ async def test_end_to_end_nomination_vote_execution(mock_discord_setup, setup_te
 
     # Set up side effect to advance to next voter
     @pytest.mark.usefixtures("setup_test_game")
-    async def alice_vote_effect(vote_val):
+    async def alice_vote_effect(vote_val, voter=None):
         # Initialize vote attributes if needed
         if not hasattr(vote, 'voted'):
             vote.voted = []
@@ -1494,7 +1494,7 @@ async def test_end_to_end_nomination_vote_execution(mock_discord_setup, setup_te
             await on_message(alice_vote_msg)
 
             # Verify vote was called with 1 (yes)
-            vote.vote.assert_called_once_with(1)
+            vote.vote.assert_called_once_with(1, voter=setup_test_game['players']['alice'])
 
     # Reset mock for next vote
     vote.vote.reset_mock()
@@ -1510,7 +1510,7 @@ async def test_end_to_end_nomination_vote_execution(mock_discord_setup, setup_te
 
     # Configure vote execution with unanimous yes
     @pytest.mark.usefixtures("setup_test_game")
-    async def bob_vote_effect(vote_val):
+    async def bob_vote_effect(vote_val, voter=None):
         # Initialize vote attributes if needed
         if not hasattr(vote, 'voted'):
             vote.voted = []
@@ -1541,7 +1541,7 @@ async def test_end_to_end_nomination_vote_execution(mock_discord_setup, setup_te
             await on_message(bob_vote_msg)
 
             # Verify vote was called with 1 (yes)
-            vote.vote.assert_called_once_with(1)
+            vote.vote.assert_called_once_with(1, voter=setup_test_game['players']['bob'])
 
     # Verify Charlie was killed (would happen in a real execution)
     # In a complete end-to-end test, this would trigger kill logic

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -541,10 +541,10 @@ async def run_command_vote(mock_discord_setup, setup_test_game):
                     vote.vote = AsyncMock()
 
                     # Directly call the command logic
-                    await vote.vote(1)  # 1 = yes vote
+                    await vote.vote(1, voter=setup_test_game['players']['alice'])  # 1 = yes vote
 
                     # Verify that vote was called with 1 (yes)
-                    vote.vote.assert_called_once_with(1)
+                    vote.vote.assert_called_once_with(1, voter=setup_test_game['players']['alice'])
 
                     # Restore original vote method
                     vote.vote = original_vote

--- a/utils/player_utils.py
+++ b/utils/player_utils.py
@@ -16,6 +16,18 @@ from utils import message_utils
 T = TypeVar('T')
 
 
+def get_player_display_name(player: Optional[model.player.Player]) -> str:
+    """Get the display name of a player or 'the storytellers' if None.
+    
+    Args:
+        player: The player to get the display name for, or None for storytellers
+        
+    Returns:
+        str: The player's display name or 'the storytellers'
+    """
+    return player.display_name if player else "the storytellers"
+
+
 def is_player(member: discord.Member) -> bool:
     """
     Check if a Discord member is a player in the current game.


### PR DESCRIPTION
The two expected user visible changes are:
- Hand raising from votes during calls for exile
- Slightly more verbose messages on CallNext (both to town square and to the storyteller).

This pull request introduces a significant refactor of the voting system by implementing a new `BaseVote` class to encapsulate shared logic, and updating the `TravelerVote` class to inherit from it. Additionally, it includes updates to imports, tests, and documentation to align with these changes.

### Refactoring and Class Design:
* Added a new abstract `BaseVote` class in `model/game/base_vote.py` to centralize common voting logic, including attributes, methods for vote management, and abstract methods for customization by subclasses.
* Refactored `TravelerVote` in `model/game/traveler_vote.py` to inherit from `BaseVote`, removing redundant code and implementing abstract methods for voting order, majority calculation, and outcome determination.

### Import and Module Updates:
* Updated `model/__init__.py` to include `TravelerVote` in the imports and the `__all__` list for proper module export. [[1]](diffhunk://#diff-08297ac4d951bb17c5606e08bd75066435e34325dc09c0a77cea10197845c9c5L9-R9) [[2]](diffhunk://#diff-08297ac4d951bb17c5606e08bd75066435e34325dc09c0a77cea10197845c9c5R24)

### Test Updates:
* Updated `tests/core/test_vote_class.py` to include `TravelerVote` in the imports and adjusted test cases to reflect changes in the voting logic, including additional validation for storyteller notifications and vote announcements. [[1]](diffhunk://#diff-cd66d27e429274664fad8ea803faa8cefefa4ac90c9967274cd5303d3857698eL11-R11) [[2]](diffhunk://#diff-cd66d27e429274664fad8ea803faa8cefefa4ac90c9967274cd5303d3857698eR104-R105) [[3]](diffhunk://#diff-cd66d27e429274664fad8ea803faa8cefefa4ac90c9967274cd5303d3857698eL129-R134)