### PR TITLE
Feature/update riot impl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ WORKDIR /app
 # Install any dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
+ENV FIVEOFSWORDS_LOG_LEVEL=INFO
+
 CMD ["python", "./bot.py"]

--- a/bot_client.py
+++ b/bot_client.py
@@ -9,8 +9,12 @@ _member_cache: discord.MemberCacheFlags
 client: discord.Client
 logger: logging.Logger
 
+_LOG_LEVEL_ENV_VAR = "FIVEOFSWORDS_LOG_LEVEL"
+
 logger = logging.getLogger("discord")
-logger.setLevel(logging.WARNING)
+_configured_log_level = os.environ.get(_LOG_LEVEL_ENV_VAR, "DEBUG").upper()
+_resolved_log_level = getattr(logging, _configured_log_level, logging.DEBUG)
+logger.setLevel(_resolved_log_level)
 handler = logging.FileHandler(filename="discord.log", encoding="utf-8", mode="w")
 handler.setFormatter(
     logging.Formatter("%(asctime)s:%(levelname)s:%(name)s: %(message)s")

--- a/bot_impl.py
+++ b/bot_impl.py
@@ -1817,6 +1817,7 @@ async def on_message(message):
                         bot_client.logger.info("riot.nominate_command denied reason=non_player_non_st author=%s", message.author.display_name)
                         return
                     else:
+                        current_day_number = len(global_vars.game.days)
                         living_unpoisoned_riots = len([
                             player for player in global_vars.game.seatingOrder
                             if player.character.role_name == "Riot"
@@ -1824,8 +1825,9 @@ async def on_message(message):
                             if not player.is_ghost
                         ])
                         bot_client.logger.info(
-                            "riot.nominate_command st_override_check author=%s living_unpoisoned_riots=%s",
+                            "riot.nominate_command st_override_check author=%s day=%s living_unpoisoned_riots=%s",
                             message.author.display_name,
+                            current_day_number,
                             living_unpoisoned_riots,
                         )
                         if living_unpoisoned_riots > 0:
@@ -1906,10 +1908,18 @@ async def on_message(message):
                     return
 
                 if global_vars.gamemaster_role in global_vars.server.get_member(message.author.id).roles:
+                    living_unpoisoned_riots = len([
+                        player for player in global_vars.game.seatingOrder
+                        if player.character.role_name == "Riot"
+                        if not player.character.is_poisoned
+                        if not player.is_ghost
+                    ])
                     bot_client.logger.info(
-                        "riot.nominate_command st_nomination nominee=%s st=%s",
+                        "riot.nominate_command st_nomination nominee=%s st=%s day=%s living_unpoisoned_riots=%s delegation=day.nomination",
                         person.display_name if person else "storytellers",
                         message.author.display_name,
+                        len(global_vars.game.days),
+                        living_unpoisoned_riots,
                     )
                     await global_vars.game.days[-1].nomination(person, None)
                     if global_vars.game is not game.NULL_GAME:

--- a/bot_impl.py
+++ b/bot_impl.py
@@ -1826,7 +1826,7 @@ async def on_message(message):
                 person = await player_utils.select_player(
                     message.author, argument, global_vars.game.seatingOrder
                 ) if not story_teller_is_nominated else None
-                bot_client.logger.info(
+                bot_client.logger.debug(
                     "riot.nominate_command start author=%s nominator_player=%s nominee=%s storyteller_nominee=%s riot_active=%s",
                     message.author.display_name,
                     nominator_player.display_name if nominator_player else None,
@@ -1844,7 +1844,7 @@ async def on_message(message):
                 if not nominator_player:
                     if not global_vars.gamemaster_role in global_vars.server.get_member(message.author.id).roles:
                         await message_utils.safe_send(message.author, "You aren't in the game, and so cannot nominate.")
-                        bot_client.logger.info("riot.nominate_command denied reason=non_player_non_st author=%s", message.author.display_name)
+                        bot_client.logger.debug("riot.nominate_command denied reason=non_player_non_st author=%s", message.author.display_name)
                         return
                     else:
                         current_day_number = len(global_vars.game.days)
@@ -1854,7 +1854,7 @@ async def on_message(message):
                             if not player.character.is_poisoned
                             if not player.is_ghost
                         ])
-                        bot_client.logger.info(
+                        bot_client.logger.debug(
                             "riot.nominate_command st_override_check author=%s day=%s living_unpoisoned_riots=%s",
                             message.author.display_name,
                             current_day_number,
@@ -1890,7 +1890,7 @@ async def on_message(message):
                                 )
                                 return
                             global_vars.game.days[-1].st_riot_kill_override = player_dies
-                            bot_client.logger.info(
+                            bot_client.logger.debug(
                                 "riot.nominate_command st_override_set nominee=%s player_dies=%s",
                                 person.display_name if person else "storytellers",
                                 player_dies,
@@ -1906,7 +1906,7 @@ async def on_message(message):
                     if global_vars.game.days[-1].riot_active:
                         if not nominator_player.riot_nominee:
                             await message_utils.safe_send(message.author, "Riot is active, you may not nominate.")
-                            bot_client.logger.info(
+                            bot_client.logger.debug(
                                 "riot.nominate_command denied reason=not_current_riot_nominee nominator=%s",
                                 nominator_player.display_name,
                             )
@@ -1925,7 +1925,7 @@ async def on_message(message):
 
                 if global_vars.game.is_atheist:
                     if story_teller_is_nominated:
-                        bot_client.logger.info(
+                        bot_client.logger.debug(
                             "riot.nominate_command atheist_storyteller_nomination nominator=%s riot_active=%s",
                             nominator_player.display_name if nominator_player else "storytellers",
                             global_vars.game.days[-1].riot_active,
@@ -1960,7 +1960,7 @@ async def on_message(message):
                         if not player.character.is_poisoned
                         if not player.is_ghost
                     ])
-                    bot_client.logger.info(
+                    bot_client.logger.debug(
                         "riot.nominate_command st_nomination nominee=%s st=%s day=%s living_unpoisoned_riots=%s delegation=day.nomination",
                         person.display_name if person else "storytellers",
                         message.author.display_name,
@@ -1989,7 +1989,7 @@ async def on_message(message):
                 )
                 if not nomination_ok:
                     return
-                bot_client.logger.info(
+                bot_client.logger.debug(
                     "riot.nominate_command submitted nominee=%s nominator=%s",
                     person.display_name,
                     nominator_player.display_name,
@@ -2942,7 +2942,7 @@ async def on_message_edit(before, after):
                 return
             if global_vars.game.days[-1].riot_active and not message_author_player.riot_nominee:
                 await message_utils.safe_send(global_vars.channel, "Riot is active. It is not your turn to nominate.")
-                bot_client.logger.info(
+                bot_client.logger.debug(
                     "riot.pin_nominate denied reason=not_current_riot_nominee author=%s",
                     message_author_player.display_name,
                 )
@@ -2956,7 +2956,7 @@ async def on_message_edit(before, after):
             if global_vars.game.is_atheist:
                 storyteller_nomination = await model.game.vote.is_storyteller(argument)
                 if storyteller_nomination:
-                    bot_client.logger.info(
+                    bot_client.logger.debug(
                         "riot.pin_nominate atheist_storyteller_nomination author=%s riot_active=%s",
                         message_author_player.display_name,
                         global_vars.game.days[-1].riot_active,
@@ -3005,7 +3005,7 @@ async def on_message_edit(before, after):
                 if not nomination_ok:
                     await after.unpin()
                     return
-                bot_client.logger.info(
+                bot_client.logger.debug(
                     "riot.pin_nominate submitted nominee=%s nominator=%s",
                     names[0].display_name,
                     message_author_player.display_name,

--- a/bot_impl.py
+++ b/bot_impl.py
@@ -1796,6 +1796,14 @@ async def on_message(message):
                 person = await player_utils.select_player(
                     message.author, argument, global_vars.game.seatingOrder
                 ) if not story_teller_is_nominated else None
+                bot_client.logger.info(
+                    "riot.nominate_command start author=%s nominator_player=%s nominee=%s storyteller_nominee=%s riot_active=%s",
+                    message.author.display_name,
+                    nominator_player.display_name if nominator_player else None,
+                    person.display_name if person else None,
+                    story_teller_is_nominated,
+                    global_vars.game.days[-1].riot_active,
+                )
 
                 traveler_called = person is not None and isinstance(person.character, model.characters.Traveler)
 
@@ -1806,14 +1814,21 @@ async def on_message(message):
                 if not nominator_player:
                     if not global_vars.gamemaster_role in global_vars.server.get_member(message.author.id).roles:
                         await message_utils.safe_send(message.author, "You aren't in the game, and so cannot nominate.")
+                        bot_client.logger.info("riot.nominate_command denied reason=non_player_non_st author=%s", message.author.display_name)
                         return
                     else:
-                        if len([
+                        living_unpoisoned_riots = len([
                             player for player in global_vars.game.seatingOrder
                             if player.character.role_name == "Riot"
                             if not player.character.is_poisoned
                             if not player.is_ghost
-                        ]) > 0:
+                        ])
+                        bot_client.logger.info(
+                            "riot.nominate_command st_override_check author=%s living_unpoisoned_riots=%s",
+                            message.author.display_name,
+                            living_unpoisoned_riots,
+                        )
+                        if living_unpoisoned_riots > 0:
                             # todo: ask if the nominee dies
                             st_user = message.author
                             msg = await message_utils.safe_send(st_user, "Do they die? yes or no")
@@ -1843,10 +1858,19 @@ async def on_message(message):
                                 )
                                 return
                             global_vars.game.days[-1].st_riot_kill_override = player_dies
+                            bot_client.logger.info(
+                                "riot.nominate_command st_override_set nominee=%s player_dies=%s",
+                                person.display_name if person else "storytellers",
+                                player_dies,
+                            )
                 else:
                     if global_vars.game.days[-1].riot_active:
                         if not nominator_player.riot_nominee:
                             await message_utils.safe_send(message.author, "Riot is active, you may not nominate.")
+                            bot_client.logger.info(
+                                "riot.nominate_command denied reason=not_current_riot_nominee nominator=%s",
+                                nominator_player.display_name,
+                            )
                             return
                     if nominator_player.is_ghost and not traveler_called and not nominator_player.riot_nominee and not banshee_override:
                         await message_utils.safe_send(
@@ -1862,6 +1886,11 @@ async def on_message(message):
 
                 if global_vars.game.is_atheist:
                     if story_teller_is_nominated:
+                        bot_client.logger.info(
+                            "riot.nominate_command atheist_storyteller_nomination nominator=%s riot_active=%s",
+                            nominator_player.display_name if nominator_player else "storytellers",
+                            global_vars.game.days[-1].riot_active,
+                        )
                         if None in [x.nominee for x in global_vars.game.days[-1].votes]:
                             await message_utils.safe_send(message.author,
                                                           "The storytellers have already been nominated today.")
@@ -1877,6 +1906,11 @@ async def on_message(message):
                     return
 
                 if global_vars.gamemaster_role in global_vars.server.get_member(message.author.id).roles:
+                    bot_client.logger.info(
+                        "riot.nominate_command st_nomination nominee=%s st=%s",
+                        person.display_name if person else "storytellers",
+                        message.author.display_name,
+                    )
                     await global_vars.game.days[-1].nomination(person, None)
                     if global_vars.game is not game.NULL_GAME:
                         game_utils.backup("current_game.pckl")
@@ -1891,6 +1925,11 @@ async def on_message(message):
                 model.game.vote.remove_banshee_nomination(banshee_ability_of_player)
 
                 await global_vars.game.days[-1].nomination(person, nominator_player)
+                bot_client.logger.info(
+                    "riot.nominate_command submitted nominee=%s nominator=%s",
+                    person.display_name,
+                    nominator_player.display_name,
+                )
                 if global_vars.game is not game.NULL_GAME:
                     game_utils.backup("current_game.pckl")
                 return
@@ -2830,6 +2869,10 @@ async def on_message_edit(before, after):
                 return
             if global_vars.game.days[-1].riot_active and not message_author_player.riot_nominee:
                 await message_utils.safe_send(global_vars.channel, "Riot is active. It is not your turn to nominate.")
+                bot_client.logger.info(
+                    "riot.pin_nominate denied reason=not_current_riot_nominee author=%s",
+                    message_author_player.display_name,
+                )
                 await after.unpin()
                 return
             if not (message_author_player).can_nominate and not traveler_called and not banshee_override:
@@ -2840,6 +2883,11 @@ async def on_message_edit(before, after):
             if global_vars.game.is_atheist:
                 storyteller_nomination = await model.game.vote.is_storyteller(argument)
                 if storyteller_nomination:
+                    bot_client.logger.info(
+                        "riot.pin_nominate atheist_storyteller_nomination author=%s riot_active=%s",
+                        message_author_player.display_name,
+                        global_vars.game.days[-1].riot_active,
+                    )
                     if None in [x.nominee for x in global_vars.game.days[-1].votes]:
                         await message_utils.safe_send(
                             global_vars.channel,
@@ -2866,6 +2914,11 @@ async def on_message_edit(before, after):
                 model.game.vote.remove_banshee_nomination(banshee_ability_of_player)
 
                 await global_vars.game.days[-1].nomination(names[0], message_author_player)
+                bot_client.logger.info(
+                    "riot.pin_nominate submitted nominee=%s nominator=%s",
+                    names[0].display_name,
+                    message_author_player.display_name,
+                )
                 if global_vars.game is not game.NULL_GAME:
                     game_utils.backup("current_game.pckl")
                 await after.unpin()

--- a/bot_impl.py
+++ b/bot_impl.py
@@ -57,6 +57,36 @@ except ImportError:
 # Load all commands into the registry
 commands.loader.load_all_commands()
 
+
+async def _send_nomination_denial_if_needed(current_day, nominator_player, denial_recipient, log_context: str) -> bool:
+    """Send standardized domain nomination denial, returning True when blocked."""
+    denial_reason = current_day.nomination_denial_reason(nominator_player)
+    if not denial_reason:
+        return False
+    bot_client.logger.info(
+        "%s denied reason=%s nominator=%s",
+        log_context,
+        denial_reason,
+        nominator_player.display_name if nominator_player else None,
+    )
+    await message_utils.safe_send(denial_recipient, current_day.nomination_denial_message(denial_reason))
+    return True
+
+
+async def _submit_nomination_with_domain_result(current_day, nominee, nominator, denial_recipient, log_context: str) -> bool:
+    """Execute Day.nomination and handle any domain denial result consistently."""
+    denial_reason = await current_day.nomination(nominee, nominator)
+    if not denial_reason:
+        return True
+    bot_client.logger.info(
+        "%s denied reason=%s nominator=%s",
+        log_context,
+        denial_reason,
+        nominator.display_name if nominator else None,
+    )
+    await message_utils.safe_send(denial_recipient, current_day.nomination_denial_message(denial_reason))
+    return False
+
 ### API Stuff
 try:
     member_cache = discord.MemberCacheFlags(
@@ -1866,6 +1896,13 @@ async def on_message(message):
                                 player_dies,
                             )
                 else:
+                    if await _send_nomination_denial_if_needed(
+                        global_vars.game.days[-1],
+                        nominator_player,
+                        message.author,
+                        "riot.nominate_command",
+                    ):
+                        return
                     if global_vars.game.days[-1].riot_active:
                         if not nominator_player.riot_nominee:
                             await message_utils.safe_send(message.author, "Riot is active, you may not nominate.")
@@ -1898,7 +1935,16 @@ async def on_message(message):
                                                           "The storytellers have already been nominated today.")
                             await message.unpin()
                             return
-                        await global_vars.game.days[-1].nomination(None, nominator_player)
+                        nomination_ok = await _submit_nomination_with_domain_result(
+                            global_vars.game.days[-1],
+                            None,
+                            nominator_player,
+                            message.author,
+                            "riot.nominate_command",
+                        )
+                        if not nomination_ok:
+                            await message.unpin()
+                            return
                         if global_vars.game is not game.NULL_GAME:
                             game_utils.backup("current_game.pckl")
                         await message.unpin()
@@ -1934,7 +1980,15 @@ async def on_message(message):
 
                 model.game.vote.remove_banshee_nomination(banshee_ability_of_player)
 
-                await global_vars.game.days[-1].nomination(person, nominator_player)
+                nomination_ok = await _submit_nomination_with_domain_result(
+                    global_vars.game.days[-1],
+                    person,
+                    nominator_player,
+                    message.author,
+                    "riot.nominate_command",
+                )
+                if not nomination_ok:
+                    return
                 bot_client.logger.info(
                     "riot.nominate_command submitted nominee=%s nominator=%s",
                     person.display_name,
@@ -2862,6 +2916,15 @@ async def on_message_edit(before, after):
                 await after.unpin()
                 return
 
+            if await _send_nomination_denial_if_needed(
+                global_vars.game.days[-1],
+                message_author_player,
+                global_vars.channel,
+                "riot.pin_nominate",
+            ):
+                await after.unpin()
+                return
+
             names = await player_utils.generate_possibilities(argument, global_vars.game.seatingOrder)
             traveler_called = len(names) == 1 and isinstance(names[0].character, model.characters.Traveler)
 
@@ -2906,7 +2969,16 @@ async def on_message_edit(before, after):
                         await after.unpin()
                         return
                     model.game.vote.remove_banshee_nomination(banshee_ability_of_player)
-                    await global_vars.game.days[-1].nomination(None, message_author_player)
+                    nomination_ok = await _submit_nomination_with_domain_result(
+                        global_vars.game.days[-1],
+                        None,
+                        message_author_player,
+                        global_vars.channel,
+                        "riot.pin_nominate",
+                    )
+                    if not nomination_ok:
+                        await after.unpin()
+                        return
                     if global_vars.game is not game.NULL_GAME:
                         game_utils.backup("current_game.pckl")
                     await after.unpin()
@@ -2923,7 +2995,16 @@ async def on_message_edit(before, after):
 
                 model.game.vote.remove_banshee_nomination(banshee_ability_of_player)
 
-                await global_vars.game.days[-1].nomination(names[0], message_author_player)
+                nomination_ok = await _submit_nomination_with_domain_result(
+                    global_vars.game.days[-1],
+                    names[0],
+                    message_author_player,
+                    global_vars.channel,
+                    "riot.pin_nominate",
+                )
+                if not nomination_ok:
+                    await after.unpin()
+                    return
                 bot_client.logger.info(
                     "riot.pin_nominate submitted nominee=%s nominator=%s",
                     names[0].display_name,

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -1996,17 +1996,27 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         # TODO: Future work - Golem smash should apply BEFORE Riot execute (sequencing issue)
 
         # Kill the nominee (all nominees die during Riot chaining)
+        did_kill = False
         if not nominator:
             if this_day.st_riot_kill_override:
                 this_day.st_riot_kill_override = False
                 bot_client.logger.debug("riot.nomination kill decision=execute_by_st_override nominee=%s", nominee_name)
-                await nominee.kill()
+                did_kill = await nominee.kill()
             else:
                 bot_client.logger.debug("riot.nomination kill decision=spare_by_st_override nominee=%s", nominee_name)
         else:
             # Riots always kill their nominees
             bot_client.logger.debug("riot.nomination kill decision=execute nominee=%s", nominee_name)
-            await nominee.kill()
+            did_kill = await nominee.kill()
+
+        if did_kill:
+            living_players = [player for player in global_vars.game.seatingOrder if not player.is_ghost]
+            if len(living_players) <= 2:
+                await utils.message_utils.safe_send(
+                    global_vars.channel,
+                    "The game is over! Please wait for the storytellers to conclude the game.",
+                )
+                return False
 
         riot_announcement = f"Riot is in play. {nominee.user.mention} to nominate"
         

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -1871,6 +1871,15 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         assert global_vars.game is not None
         nominee_name = nominee.display_name if nominee else "storytellers"
         nominator_name = nominator.display_name if nominator else "storytellers"
+        nomination_source = "storyteller" if nominator is None else "player"
+        current_day_number = len(global_vars.game.days)
+        eligible_riots = [
+            player for player in global_vars.game.seatingOrder
+            if player.character.role_name == "Riot"
+            if not player.character.is_poisoned
+            if not player.is_ghost
+        ]
+        eligible_riot_count = len(eligible_riots)
         bot_client.logger.info(
             "riot.nomination start proceed=%s nominee=%s nominator=%s automated=%s poisoned=%s riot_ghost=%s",
             proceed,
@@ -1880,37 +1889,51 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             self.is_poisoned,
             self.parent.is_ghost,
         )
+        bot_client.logger.info(
+            "riot.nomination eligibility source=%s day=%s eligible_riot_count=%s",
+            nomination_source,
+            current_day_number,
+            eligible_riot_count,
+        )
         if not global_vars.game.has_automated_life_and_death:
             bot_client.logger.info("riot.nomination decision=pass_through reason=automation_disabled")
             return proceed
 
-        # todo: is not nominee indicative of the storytellers being nominated?
-        
-        # Don't chain if Riot is poisoned or a ghost
-        if self.is_poisoned or self.parent.is_ghost or not nominee:
-            reasons = []
-            if self.is_poisoned:
-                reasons.append("riot_poisoned")
-            if self.parent.is_ghost:
-                reasons.append("riot_dead")
-            if not nominee:
-                reasons.append("storyteller_nomination")
+        if not nominee:
             bot_client.logger.info(
-                "riot.nomination decision=pass_through reason=%s",
-                ",".join(reasons),
+                "riot.nomination decision=pass_through reason=storyteller_nominee source=%s day=%s eligible_riot_count=%s",
+                nomination_source,
+                current_day_number,
+                eligible_riot_count,
             )
             return proceed
-        
+
         this_day = global_vars.game.days[-1]
-        current_day_number = len(global_vars.game.days)
-        
+
         # Days 1-2: Regular nominations, no riot behavior
         if current_day_number < 3:
             bot_client.logger.info(
-                "riot.nomination decision=pass_through reason=pre_day3 day=%s",
+                "riot.nomination decision=pass_through reason=pre_day3 day=%s source=%s eligible_riot_count=%s",
                 current_day_number,
+                nomination_source,
+                eligible_riot_count,
             )
             return proceed
+
+        if eligible_riot_count < 1:
+            bot_client.logger.info(
+                "riot.nomination decision=pass_through reason=no_eligible_riot day=%s source=%s",
+                current_day_number,
+                nomination_source,
+            )
+            return proceed
+
+        bot_client.logger.info(
+            "riot.nomination decision=chain reason=eligible_riot_present day=%s source=%s eligible_riot_count=%s",
+            current_day_number,
+            nomination_source,
+            eligible_riot_count,
+        )
         
         # Day 3: Riot chaining behavior
         nominee_nick = nominator.display_name if nominator else "the storytellers"
@@ -1960,7 +1983,12 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             await utils.message_utils.safe_send(global_vars.channel, messageText)
             
         this_day.riot_active = True
-        bot_client.logger.info("riot.nomination riot_chain_activated day=%s", current_day_number)
+        bot_client.logger.info(
+            "riot.nomination riot_chain_activated day=%s source=%s eligible_riot_count=%s",
+            current_day_number,
+            nomination_source,
+            eligible_riot_count,
+        )
         
         # REMOVED: Old soldier_jinx and golem_jinx logic
         # Soldier jinx is handled by storyteller intervention (they stop the game and announce good wins)
@@ -2004,7 +2032,10 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         bot_client.logger.info("riot.nomination prompt_sent message_id=%s", msg.id if msg else None)
         
         await this_day.open_noms()
-        bot_client.logger.info("riot.nomination decision=intercept proceed=False")
+        bot_client.logger.info(
+            "riot.nomination decision=intercept proceed=False source=%s",
+            nomination_source,
+        )
         return False
 
 

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -1827,7 +1827,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         )
         if not global_vars.game.has_automated_life_and_death:
             # if there is a riot alive on day 3 and the game does not have automated life and death, prompt sts to set it.
-            if current_day_number >= 3 and not self.parent.is_ghost:
+            if current_day_number >= 3 and not self.parent.is_ghost and not self.day_3_notification_sent:
                 await utils.message_utils.notify_storytellers("A Riot is in play. Use the `automatekills true` command to enable Riot chaining")
                 self.day_3_notification_sent = True
 

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -1818,7 +1818,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
 
     async def on_day_start(self, origin, kills):
         current_day_number = len(global_vars.game.days) + 1
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "riot.day_start automated=%s day=%s poisoned=%s riot_ghost=%s",
             global_vars.game.has_automated_life_and_death,
             current_day_number,
@@ -1826,20 +1826,20 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             self.parent.is_ghost,
         )
         if not global_vars.game.has_automated_life_and_death:
-            bot_client.logger.info("riot.day_start decision=skip reason=automation_disabled")
+            bot_client.logger.debug("riot.day_start decision=skip reason=automation_disabled")
             return True
 
         # Check if there's a minion in the game
         has_minion = any(isinstance(player.character, base.Minion) for player in global_vars.game.seatingOrder)
 
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "riot.day_start minion_check has_minion=%s notification_sent=%s",
             has_minion,
             self.day_3_notification_sent,
         )
         if current_day_number >= 3 and not self.day_3_notification_sent and has_minion:
             self.day_3_notification_sent = True
-            bot_client.logger.info(
+            bot_client.logger.debug(
                 "riot.day_start decision=notify_storytellers day=%s",
                 current_day_number,
             )
@@ -1855,16 +1855,16 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         # fixme: only if ALL riots are poisoned should this message be sent.
         # If Riot is poisoned, don't chain (storytellers handle the decision)
         if self.is_poisoned:
-            bot_client.logger.info("riot.day_start decision=non_chaining reason=riot_poisoned")
+            bot_client.logger.debug("riot.day_start decision=non_chaining reason=riot_poisoned")
             await utils.message_utils.safe_send(origin, "There is a poisoned riot on day 3. What happens now is up to the storytellers.")
             return True
 
         # If Riot is a ghost, don't chain
         if self.parent.is_ghost:
-            bot_client.logger.info("riot.day_start decision=non_chaining reason=riot_dead")
+            bot_client.logger.debug("riot.day_start decision=non_chaining reason=riot_dead")
             return True
 
-        bot_client.logger.info("riot.day_start decision=ready")
+        bot_client.logger.debug("riot.day_start decision=ready")
         return True
 
     async def on_nomination(self, nominee, nominator, proceed):
@@ -1880,7 +1880,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             if not player.is_ghost
         ]
         eligible_riot_count = len(eligible_riots)
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "riot.nomination start proceed=%s nominee=%s nominator=%s automated=%s poisoned=%s riot_ghost=%s",
             proceed,
             nominee_name,
@@ -1889,18 +1889,18 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             self.is_poisoned,
             self.parent.is_ghost,
         )
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "riot.nomination eligibility source=%s day=%s eligible_riot_count=%s",
             nomination_source,
             current_day_number,
             eligible_riot_count,
         )
         if not global_vars.game.has_automated_life_and_death:
-            bot_client.logger.info("riot.nomination decision=pass_through reason=automation_disabled")
+            bot_client.logger.debug("riot.nomination decision=pass_through reason=automation_disabled")
             return proceed
 
         if not nominee:
-            bot_client.logger.info(
+            bot_client.logger.debug(
                 "riot.nomination decision=pass_through reason=storyteller_nominee source=%s day=%s eligible_riot_count=%s",
                 nomination_source,
                 current_day_number,
@@ -1912,7 +1912,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
 
         # Days 1-2: Regular nominations, no riot behavior
         if current_day_number < 3:
-            bot_client.logger.info(
+            bot_client.logger.debug(
                 "riot.nomination decision=pass_through reason=pre_day3 day=%s source=%s eligible_riot_count=%s",
                 current_day_number,
                 nomination_source,
@@ -1921,14 +1921,14 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             return proceed
 
         if eligible_riot_count < 1:
-            bot_client.logger.info(
+            bot_client.logger.debug(
                 "riot.nomination decision=pass_through reason=no_eligible_riot day=%s source=%s",
                 current_day_number,
                 nomination_source,
             )
             return proceed
 
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "riot.nomination decision=chain reason=eligible_riot_present day=%s source=%s eligible_riot_count=%s",
             current_day_number,
             nomination_source,
@@ -1946,7 +1946,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             await announcement.pin()
         else:
             bot_client.logger.warning("announcent to pin not received!")
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "riot.nomination announce nominee=%s nominator=%s announcement_id=%s",
             nominee_name,
             nominator_name,
@@ -1983,7 +1983,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             await utils.message_utils.safe_send(global_vars.channel, messageText)
             
         this_day.riot_active = True
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "riot.nomination riot_chain_activated day=%s source=%s eligible_riot_count=%s",
             current_day_number,
             nomination_source,
@@ -1999,13 +1999,13 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         if not nominator:
             if this_day.st_riot_kill_override:
                 this_day.st_riot_kill_override = False
-                bot_client.logger.info("riot.nomination kill decision=execute_by_st_override nominee=%s", nominee_name)
+                bot_client.logger.debug("riot.nomination kill decision=execute_by_st_override nominee=%s", nominee_name)
                 await nominee.kill()
             else:
-                bot_client.logger.info("riot.nomination kill decision=spare_by_st_override nominee=%s", nominee_name)
+                bot_client.logger.debug("riot.nomination kill decision=spare_by_st_override nominee=%s", nominee_name)
         else:
             # Riots always kill their nominees
-            bot_client.logger.info("riot.nomination kill decision=execute nominee=%s", nominee_name)
+            bot_client.logger.debug("riot.nomination kill decision=execute nominee=%s", nominee_name)
             await nominee.kill()
 
         riot_announcement = f"Riot is in play. {nominee.user.mention} to nominate"
@@ -2019,7 +2019,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         if nominee:
             nominee.riot_nominee = True
             nominee.can_nominate = True
-            bot_client.logger.info(
+            bot_client.logger.debug(
                 "riot.nomination next_nominator nominee=%s can_nominate=%s",
                 nominee_name,
                 nominee.can_nominate,
@@ -2029,10 +2029,10 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             global_vars.channel,
             riot_announcement,
         )
-        bot_client.logger.info("riot.nomination prompt_sent message_id=%s", msg.id if msg else None)
+        bot_client.logger.debug("riot.nomination prompt_sent message_id=%s", msg.id if msg else None)
         
         await this_day.open_noms()
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "riot.nomination decision=intercept proceed=False source=%s",
             nomination_source,
         )

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -1817,15 +1817,32 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         self.day_3_notification_sent = False
 
     async def on_day_start(self, origin, kills):
+        current_day_number = len(global_vars.game.days) + 1
+        bot_client.logger.info(
+            "riot.day_start automated=%s day=%s poisoned=%s riot_ghost=%s",
+            global_vars.game.has_automated_life_and_death,
+            current_day_number,
+            self.is_poisoned,
+            self.parent.is_ghost,
+        )
         if not global_vars.game.has_automated_life_and_death:
+            bot_client.logger.info("riot.day_start decision=skip reason=automation_disabled")
             return True
 
         # Check if there's a minion in the game
         has_minion = any(isinstance(player.character, base.Minion) for player in global_vars.game.seatingOrder)
 
-        current_day_number = len(global_vars.game.days) + 1
+        bot_client.logger.info(
+            "riot.day_start minion_check has_minion=%s notification_sent=%s",
+            has_minion,
+            self.day_3_notification_sent,
+        )
         if current_day_number >= 3 and not self.day_3_notification_sent and has_minion:
             self.day_3_notification_sent = True
+            bot_client.logger.info(
+                "riot.day_start decision=notify_storytellers day=%s",
+                current_day_number,
+            )
 
             # Send minion update reminder regardless of Riot's state
             # (even if poisoned or ghost, storytellers need to update minions) 
@@ -1838,24 +1855,50 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         # fixme: only if ALL riots are poisoned should this message be sent.
         # If Riot is poisoned, don't chain (storytellers handle the decision)
         if self.is_poisoned:
+            bot_client.logger.info("riot.day_start decision=non_chaining reason=riot_poisoned")
             await utils.message_utils.safe_send(origin, "There is a poisoned riot on day 3. What happens now is up to the storytellers.")
             return True
 
         # If Riot is a ghost, don't chain
         if self.parent.is_ghost:
+            bot_client.logger.info("riot.day_start decision=non_chaining reason=riot_dead")
             return True
 
+        bot_client.logger.info("riot.day_start decision=ready")
         return True
 
     async def on_nomination(self, nominee, nominator, proceed):
         assert global_vars.game is not None
+        nominee_name = nominee.display_name if nominee else "storytellers"
+        nominator_name = nominator.display_name if nominator else "storytellers"
+        bot_client.logger.info(
+            "riot.nomination start proceed=%s nominee=%s nominator=%s automated=%s poisoned=%s riot_ghost=%s",
+            proceed,
+            nominee_name,
+            nominator_name,
+            global_vars.game.has_automated_life_and_death,
+            self.is_poisoned,
+            self.parent.is_ghost,
+        )
         if not global_vars.game.has_automated_life_and_death:
+            bot_client.logger.info("riot.nomination decision=pass_through reason=automation_disabled")
             return proceed
 
         # todo: is not nominee indicative of the storytellers being nominated?
         
         # Don't chain if Riot is poisoned or a ghost
         if self.is_poisoned or self.parent.is_ghost or not nominee:
+            reasons = []
+            if self.is_poisoned:
+                reasons.append("riot_poisoned")
+            if self.parent.is_ghost:
+                reasons.append("riot_dead")
+            if not nominee:
+                reasons.append("storyteller_nomination")
+            bot_client.logger.info(
+                "riot.nomination decision=pass_through reason=%s",
+                ",".join(reasons),
+            )
             return proceed
         
         this_day = global_vars.game.days[-1]
@@ -1863,6 +1906,10 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         
         # Days 1-2: Regular nominations, no riot behavior
         if current_day_number < 3:
+            bot_client.logger.info(
+                "riot.nomination decision=pass_through reason=pre_day3 day=%s",
+                current_day_number,
+            )
             return proceed
         
         # Day 3: Riot chaining behavior
@@ -1876,6 +1923,12 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             await announcement.pin()
         else:
             bot_client.logger.warning("announcent to pin not received!")
+        bot_client.logger.info(
+            "riot.nomination announce nominee=%s nominator=%s announcement_id=%s",
+            nominee_name,
+            nominator_name,
+            announcement.id if announcement else None,
+        )
         this_day.votes[-1].announcements.append(announcement.id)
         
         if not this_day.riot_active and global_vars.game.show_tally:
@@ -1907,6 +1960,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             await utils.message_utils.safe_send(global_vars.channel, messageText)
             
         this_day.riot_active = True
+        bot_client.logger.info("riot.nomination riot_chain_activated day=%s", current_day_number)
         
         # REMOVED: Old soldier_jinx and golem_jinx logic
         # Soldier jinx is handled by storyteller intervention (they stop the game and announce good wins)
@@ -1917,9 +1971,13 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         if not nominator:
             if this_day.st_riot_kill_override:
                 this_day.st_riot_kill_override = False
+                bot_client.logger.info("riot.nomination kill decision=execute_by_st_override nominee=%s", nominee_name)
                 await nominee.kill()
+            else:
+                bot_client.logger.info("riot.nomination kill decision=spare_by_st_override nominee=%s", nominee_name)
         else:
             # Riots always kill their nominees
+            bot_client.logger.info("riot.nomination kill decision=execute nominee=%s", nominee_name)
             await nominee.kill()
 
         riot_announcement = f"Riot is in play. {nominee.user.mention} to nominate"
@@ -1933,13 +1991,20 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         if nominee:
             nominee.riot_nominee = True
             nominee.can_nominate = True
+            bot_client.logger.info(
+                "riot.nomination next_nominator nominee=%s can_nominate=%s",
+                nominee_name,
+                nominee.can_nominate,
+            )
 
         msg = await utils.message_utils.safe_send(
             global_vars.channel,
             riot_announcement,
         )
+        bot_client.logger.info("riot.nomination prompt_sent message_id=%s", msg.id if msg else None)
         
         await this_day.open_noms()
+        bot_client.logger.info("riot.nomination decision=intercept proceed=False")
         return False
 
 

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -1881,7 +1881,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             # Send minion update reminder regardless of Riot's state
             # (even if poisoned or ghost, storytellers need to update minions)
             if not notification_state["minion"]:
-                await utils.safe_send(origin, f"Riot is active on day {current_day_number}!\nPlease update all minion characters to Riot at the appropriate time{"." if (current_day_number == 3) else "?"}")
+                await utils.safe_send(origin, f"Riot is active on day {current_day_number}!\nPlease update all minion characters to Riot at the appropriate time{'.' if (current_day_number == 3) else '?'}")
                 notification_state["minion"] = True
 
         # Only if ALL living players with Riot abilities are poisoned should this message be sent.

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -1808,30 +1808,69 @@ class Ojo(base.Demon):
         self.role_name = "Ojo"
 
 
-class Riot(base.Demon, base.NominationModifier):
+class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
     """The riot."""
     
     def __init__(self, parent):
         super().__init__(parent)
         self.role_name = "Riot"
-    
+        self.day_3_notification_sent = False
+
+    async def on_day_start(self, origin, kills):
+        if not global_vars.game.has_automated_life_and_death:
+            return True
+        if self.parent.is_ghost:
+            return True
+        if self.is_poisoned:
+            await utils.message_utils.safe_send(origin, "There is a poisoned riot on day 3. What happens now is up to the storytellers.")
+            return True
+
+        # Check if there's a minion in the game
+        has_minion = any(isinstance(player.character, base.Minion) for player in global_vars.game.seatingOrder)
+
+        current_day_number = len(global_vars.game.days) + 1
+        if current_day_number >= 3 and not self.day_3_notification_sent and has_minion:
+            self.day_3_notification_sent = True
+            await utils.notify_storytellers(f"""
+                Riot is active on day {current_day_number}!
+                Please update all minion characters to Riot at the appropriate time{"." if current_day_number == 3 else "?"}
+                """.strip())
+            for memb in global_vars.gamemaster_role.members:
+                await utils.message_utils.safe_send(
+                    memb,
+                    "Riot is active on day 3! Update all Minion characters to Riot sometime today if you have not already.",
+                )
+
+        return True
+
     async def on_nomination(self, nominee, nominator, proceed):
+        assert global_vars.game is not None
         if not global_vars.game.has_automated_life_and_death:
             return proceed
         if self.is_poisoned or self.parent.is_ghost or not nominee:
             return proceed
-            
+        
+        this_day = global_vars.game.days[-1]
+        current_day_number = len(global_vars.game.days)
+        
+        # Days 1-2: Regular nominations, no riot behavior
+        if current_day_number < 3:
+            return proceed
+        
+        # Day 3: Riot chaining behavior
         nominee_nick = nominator.display_name if nominator else "the storytellers"
-        announcemnt = await utils.message_utils.safe_send(
+        announcement = await utils.message_utils.safe_send(
             global_vars.channel,
             "{}, {} has been nominated by {}."
             .format(global_vars.player_role.mention, nominee.user.mention, nominee_nick),
         )
-        await announcemnt.pin()
-        this_day = global_vars.game.days[-1]
-        this_day.votes[-1].announcements.append(announcemnt.id)
+        if announcement:
+            await announcement.pin()
+        else:
+            bot_client.logger.warning("announcent to pin not received!")
+        this_day.votes[-1].announcements.append(announcement.id)
         
-        if not this_day.riot_active:
+        if not this_day.riot_active and global_vars.game.show_tally:
             # show tally on first nomination
             import itertools
             message_tally = {
@@ -1874,9 +1913,7 @@ class Riot(base.Demon, base.NominationModifier):
             await nominee.kill()
             
         riot_announcement = f"Riot is in play. {nominee.user.mention} to nominate"
-        if len(global_vars.game.days) < 3:
-            riot_announcement = riot_announcement + " or skip"
-            
+        
         if nominator:
             nominator.riot_nominee = False
         else:

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -9,6 +9,7 @@ import bot_client
 import global_vars
 import utils.character_utils
 import utils.message_utils
+from utils import has_ability
 from . import base
 
 
@@ -1811,13 +1812,42 @@ class Ojo(base.Demon):
 class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
     """The riot."""
     
+    # Shared Riot notification state across all Riot instances.
+    __notification_sent = {
+        "day": None,
+        "automate": False,
+        "minion": False,
+        "poisoned": False,
+    }
+
     def __init__(self, parent):
         super().__init__(parent)
         self.role_name = "Riot"
-        self.day_3_notification_sent = False
+
+    @classmethod
+    def _get_notification_state(cls, current_day_number):
+        defaults = {
+            "day": None,
+            "automate": False,
+            "minion": False,
+            "poisoned": False,
+        }
+        for key, value in defaults.items():
+            cls.__notification_sent.setdefault(key, value)
+
+        if cls.__notification_sent["day"] != current_day_number:
+            cls.__notification_sent = {
+                "day": current_day_number,
+                "automate": False,
+                "minion": False,
+                "poisoned": False,
+            }
+        return cls.__notification_sent
 
     async def on_day_start(self, origin, kills):
         current_day_number = len(global_vars.game.days) + 1
+        notification_state = Riot._get_notification_state(current_day_number)
+
         bot_client.logger.debug(
             "riot.day_start automated=%s day=%s poisoned=%s riot_ghost=%s",
             global_vars.game.has_automated_life_and_death,
@@ -1827,9 +1857,9 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         )
         if not global_vars.game.has_automated_life_and_death:
             # if there is a riot alive on day 3 and the game does not have automated life and death, prompt sts to set it.
-            if current_day_number >= 3 and not self.parent.is_ghost and not self.day_3_notification_sent:
-                await utils.message_utils.notify_storytellers("A Riot is in play. Use the `automatekills true` command to enable Riot chaining")
-                self.day_3_notification_sent = True
+            if current_day_number >= 3 and not self.parent.is_ghost and not notification_state["automate"]:
+                await utils.message_utils.safe_send(origin, "A Riot is in play. Use the `automatekills true` command to enable Riot chaining")
+                notification_state["automate"] = True
 
             bot_client.logger.debug("riot.day_start decision=skip reason=automation_disabled")
             return True
@@ -1840,28 +1870,32 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         bot_client.logger.debug(
             "riot.day_start minion_check has_minion=%s notification_sent=%s",
             has_minion,
-            self.day_3_notification_sent,
+            Riot._get_notification_state(current_day_number)
         )
-        if current_day_number >= 3 and not self.day_3_notification_sent and has_minion:
-            self.day_3_notification_sent = True
+        if current_day_number >= 3 and not notification_state["minion"] and has_minion:
             bot_client.logger.debug(
                 "riot.day_start decision=notify_storytellers day=%s",
                 current_day_number,
             )
 
             # Send minion update reminder regardless of Riot's state
-            # (even if poisoned or ghost, storytellers need to update minions) 
-            # todo: --- maybe. gotta check
-            await utils.notify_storytellers(f"""
-                Riot is active on day {current_day_number}!
-                Please update all minion characters to Riot at the appropriate time{"." if current_day_number == 3 else "?"}
-                """.strip())
+            # (even if poisoned or ghost, storytellers need to update minions)
+            if not notification_state["minion"]:
+                await utils.safe_send(origin, f"Riot is active on day {current_day_number}!\nPlease update all minion characters to Riot at the appropriate time{"." if (current_day_number == 3) else "?"}")
+                notification_state["minion"] = True
 
-        # fixme: only if ALL riots are poisoned should this message be sent.
-        # If Riot is poisoned, don't chain (storytellers handle the decision)
-        if self.is_poisoned:
-            bot_client.logger.debug("riot.day_start decision=non_chaining reason=riot_poisoned")
-            await utils.message_utils.safe_send(origin, "There is a poisoned riot on day 3. What happens now is up to the storytellers.")
+        # Only if ALL living players with Riot abilities are poisoned should this message be sent.
+        # If every living Riot is poisoned, don't chain (storytellers handle the decision)
+        living_riots = [
+            player for player in global_vars.game.seatingOrder
+            if has_ability(player.character, Riot)
+               and not player.is_ghost
+        ]
+        if living_riots and all(riot_player.character.is_poisoned for riot_player in living_riots):
+            bot_client.logger.debug("riot.day_start decision=non_chaining reason=all_riots_poisoned")
+            if not notification_state["poisoned"]:
+                await utils.message_utils.safe_send(origin, "All living Riot players are currently poisoned. Use the `unpoison` command if appropriate.")
+                notification_state["poisoned"] = True
             return True
 
         # If Riot is a ghost, don't chain
@@ -1949,6 +1983,7 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         )
         if announcement:
             await announcement.pin()
+            this_day.votes[-1].announcements.append(announcement.id)
         else:
             bot_client.logger.warning("announcent to pin not received!")
         bot_client.logger.debug(
@@ -1957,7 +1992,6 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             nominator_name,
             announcement.id if announcement else None,
         )
-        this_day.votes[-1].announcements.append(announcement.id)
         
         if not this_day.riot_active and global_vars.game.show_tally:
             # show tally on first nomination
@@ -2100,3 +2134,4 @@ class Wraith(base.Minion):
     def __init__(self, parent):
         super().__init__(parent)
         self.role_name = "Wraith"
+

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -1819,11 +1819,6 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
     async def on_day_start(self, origin, kills):
         if not global_vars.game.has_automated_life_and_death:
             return True
-        if self.parent.is_ghost:
-            return True
-        if self.is_poisoned:
-            await utils.message_utils.safe_send(origin, "There is a poisoned riot on day 3. What happens now is up to the storytellers.")
-            return True
 
         # Check if there's a minion in the game
         has_minion = any(isinstance(player.character, base.Minion) for player in global_vars.game.seatingOrder)
@@ -1831,15 +1826,24 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         current_day_number = len(global_vars.game.days) + 1
         if current_day_number >= 3 and not self.day_3_notification_sent and has_minion:
             self.day_3_notification_sent = True
+
+            # Send minion update reminder regardless of Riot's state
+            # (even if poisoned or ghost, storytellers need to update minions) 
+            # todo: --- maybe. gotta check
             await utils.notify_storytellers(f"""
                 Riot is active on day {current_day_number}!
                 Please update all minion characters to Riot at the appropriate time{"." if current_day_number == 3 else "?"}
                 """.strip())
-            for memb in global_vars.gamemaster_role.members:
-                await utils.message_utils.safe_send(
-                    memb,
-                    "Riot is active on day 3! Update all Minion characters to Riot sometime today if you have not already.",
-                )
+
+        # fixme: only if ALL riots are poisoned should this message be sent.
+        # If Riot is poisoned, don't chain (storytellers handle the decision)
+        if self.is_poisoned:
+            await utils.message_utils.safe_send(origin, "There is a poisoned riot on day 3. What happens now is up to the storytellers.")
+            return True
+
+        # If Riot is a ghost, don't chain
+        if self.parent.is_ghost:
+            return True
 
         return True
 
@@ -1847,6 +1851,10 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
         assert global_vars.game is not None
         if not global_vars.game.has_automated_life_and_death:
             return proceed
+
+        # todo: is not nominee indicative of the storytellers being nominated?
+        
+        # Don't chain if Riot is poisoned or a ghost
         if self.is_poisoned or self.parent.is_ghost or not nominee:
             return proceed
         
@@ -1900,18 +1908,20 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             
         this_day.riot_active = True
         
-        # handle the soldier jinx - If Riot nominates the Soldier, the Soldier does not die
-        soldier_jinx = nominator and nominee and not nominee.character.is_poisoned and utils.character_utils.has_ability(
-            nominator.character, Riot) and utils.character_utils.has_ability(nominee.character, Soldier)
-        golem_jinx = nominator and nominee and not nominator.character.is_poisoned and not nominator.is_ghost and utils.character_utils.has_ability(
-            nominee.character, Riot) and utils.character_utils.has_ability(nominator.character, Golem)
+        # REMOVED: Old soldier_jinx and golem_jinx logic
+        # Soldier jinx is handled by storyteller intervention (they stop the game and announce good wins)
+        # Golem jinx is removed entirely per clarifications
+        # TODO: Future work - Golem smash should apply BEFORE Riot execute (sequencing issue)
+
+        # Kill the nominee (all nominees die during Riot chaining)
         if not nominator:
             if this_day.st_riot_kill_override:
                 this_day.st_riot_kill_override = False
                 await nominee.kill()
-        elif not (soldier_jinx or golem_jinx):
+        else:
+            # Riots always kill their nominees
             await nominee.kill()
-            
+
         riot_announcement = f"Riot is in play. {nominee.user.mention} to nominate"
         
         if nominator:

--- a/model/characters/specific.py
+++ b/model/characters/specific.py
@@ -1826,6 +1826,11 @@ class Riot(base.Demon, base.NominationModifier, base.DayStartModifier):
             self.parent.is_ghost,
         )
         if not global_vars.game.has_automated_life_and_death:
+            # if there is a riot alive on day 3 and the game does not have automated life and death, prompt sts to set it.
+            if current_day_number >= 3 and not self.parent.is_ghost:
+                await utils.message_utils.notify_storytellers("A Riot is in play. Use the `automatekills true` command to enable Riot chaining")
+                self.day_3_notification_sent = True
+
             bot_client.logger.debug("riot.day_start decision=skip reason=automation_disabled")
             return True
 

--- a/model/game/base_vote.py
+++ b/model/game/base_vote.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 import discord
 
+import bot_client
 import global_vars
 import model.settings
 from model import nomination_buttons
@@ -293,6 +294,19 @@ class BaseVote(ABC):
 
         # Determine outcome and apply effects
         outcome = self._determine_outcome()
+        nominee_name = player_utils.get_player_display_name(self.nominee)
+        riot_active = global_vars.game.days[-1].riot_active
+        nominee_is_storyteller = self.nominee is None
+        bot_client.logger.info(
+            "vote.end nominee=%s nominator=%s outcome=%s votes=%s majority=%s riot_active=%s storyteller_nominee=%s",
+            nominee_name,
+            player_utils.get_player_display_name(self.nominator),
+            outcome.value,
+            self.votes,
+            self.majority,
+            riot_active,
+            nominee_is_storyteller,
+        )
         await self._apply_outcome_effects(outcome)
 
         # Send announcement
@@ -373,6 +387,13 @@ class BaseVote(ABC):
     async def _finalize_vote(self) -> None:
         """Finalize vote state and reopen game interactions."""
         self.done = True
+        about_to_die = global_vars.game.days[-1].aboutToDie
+        bot_client.logger.info(
+            "vote.finalize riot_active=%s nominee=%s about_to_die=%s",
+            global_vars.game.days[-1].riot_active,
+            player_utils.get_player_display_name(self.nominee),
+            player_utils.get_player_display_name(about_to_die[0]) if about_to_die else None,
+        )
         await global_vars.game.days[-1].open_noms()
         await global_vars.game.days[-1].open_pms()
 

--- a/model/game/base_vote.py
+++ b/model/game/base_vote.py
@@ -388,6 +388,8 @@ class BaseVote(ABC):
         """Finalize vote state and reopen game interactions."""
         self.done = True
         about_to_die = global_vars.game.days[-1].aboutToDie
+        if self.nominee is None:
+            await global_vars.game.days[-1].latch_riot_storyteller_turn(source="vote.finalize_storyteller_nominee")
         bot_client.logger.info(
             "vote.finalize riot_active=%s nominee=%s about_to_die=%s",
             global_vars.game.days[-1].riot_active,

--- a/model/game/base_vote.py
+++ b/model/game/base_vote.py
@@ -297,7 +297,7 @@ class BaseVote(ABC):
         nominee_name = player_utils.get_player_display_name(self.nominee)
         riot_active = global_vars.game.days[-1].riot_active
         nominee_is_storyteller = self.nominee is None
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "vote.end nominee=%s nominator=%s outcome=%s votes=%s majority=%s riot_active=%s storyteller_nominee=%s",
             nominee_name,
             player_utils.get_player_display_name(self.nominator),
@@ -390,7 +390,7 @@ class BaseVote(ABC):
         about_to_die = global_vars.game.days[-1].aboutToDie
         if self.nominee is None:
             await global_vars.game.days[-1].latch_riot_storyteller_turn(source="vote.finalize_storyteller_nominee")
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "vote.finalize riot_active=%s nominee=%s about_to_die=%s",
             global_vars.game.days[-1].riot_active,
             player_utils.get_player_display_name(self.nominee),

--- a/model/game/day.py
+++ b/model/game/day.py
@@ -96,10 +96,20 @@ class Day:
         """
 
         global_vars.game.whisper_mode = model.game.whisper_mode.WhisperMode.NEIGHBORS
+        nominee_name = nominee.display_name if nominee else "storytellers"
+        nominator_name = nominator.display_name if nominator else "storytellers"
+        bot_client.logger.info(
+            "nomination.start nominee=%s nominator=%s riot_active=%s votes_today=%s",
+            nominee_name,
+            nominator_name,
+            self.riot_active,
+            len(self.votes),
+        )
         await self.close_noms()
 
         # todo: if organ grinder ability is active, then this first message should not be output.
         if not nominee:
+            bot_client.logger.info("nomination.branch storyteller_nominee")
             self.votes.append(Vote(nominee, nominator))
             if self.aboutToDie is not None:
                 votes_needed = int(math.ceil((max(self.aboutToDie[1].votes + 1, self.votes[-1].majority))))
@@ -142,13 +152,26 @@ class Day:
             #  There may need to be some rework based on NominationModifier priority
             for person in global_vars.game.seatingOrder:
                 if isinstance(person.character, model.characters.NominationModifier) and proceed:
+                    bot_client.logger.info(
+                        "nomination.modifier_call modifier=%s nominee=%s nominator=%s",
+                        person.character.role_name,
+                        nominee_name,
+                        nominator_name,
+                    )
                     proceed = await person.character.on_nomination(
                         nominee, nominator, proceed
                     )
+                    bot_client.logger.info(
+                        "nomination.modifier_result modifier=%s proceed=%s",
+                        person.character.role_name,
+                        proceed,
+                    )
             if not proceed:
                 # do not proceed with collecting votes
+                bot_client.logger.info("nomination.stop reason=modifier_intercepted nominee=%s", nominee_name)
                 return
         elif isinstance(nominee.character, model.characters.Traveler):
+            bot_client.logger.info("nomination.branch traveler_nominee nominee=%s", nominee_name)
             nominee.can_be_nominated = False
             self.votes.append(TravelerVote(nominee, nominator))
             announcement = await message_utils.safe_send(
@@ -171,6 +194,7 @@ class Day:
                 nominee_name, nominator_name, votes_needed, is_exile=True
             )
         else:
+            bot_client.logger.info("nomination.branch regular_nominee nominee=%s", nominee_name)
             nominee.can_be_nominated = False
             self.votes.append(Vote(nominee, nominator))
             # FIXME:there might be a case where a player earlier in the seating order makes the nomination not proceed
@@ -179,11 +203,23 @@ class Day:
             proceed = True
             for person in global_vars.game.seatingOrder:
                 if isinstance(person.character, model.characters.NominationModifier) and proceed:
+                    bot_client.logger.info(
+                        "nomination.modifier_call modifier=%s nominee=%s nominator=%s",
+                        person.character.role_name,
+                        nominee_name,
+                        nominator_name,
+                    )
                     proceed = await person.character.on_nomination(
                         nominee, nominator, proceed
                     )
+                    bot_client.logger.info(
+                        "nomination.modifier_result modifier=%s proceed=%s",
+                        person.character.role_name,
+                        proceed,
+                    )
             if not proceed:
                 # do not proceed with collecting votes
+                bot_client.logger.info("nomination.stop reason=modifier_intercepted nominee=%s", nominee_name)
                 return
             # Calculate votes needed based on whether there's already someone about to die
             if self.aboutToDie is not None:
@@ -233,11 +269,23 @@ class Day:
             #  There may need to be some rework based on NominationModifier priority
             for person in global_vars.game.seatingOrder:
                 if isinstance(person.character, model.characters.NominationModifier) and proceed:
+                    bot_client.logger.info(
+                        "nomination.modifier_call_post_announce modifier=%s nominee=%s nominator=%s",
+                        person.character.role_name,
+                        nominee_name,
+                        nominator_name,
+                    )
                     proceed = await person.character.on_nomination(
                         nominee, nominator, proceed
                     )
+                    bot_client.logger.info(
+                        "nomination.modifier_result_post_announce modifier=%s proceed=%s",
+                        person.character.role_name,
+                        proceed,
+                    )
             if not proceed:
                 # do not proceed with collecting user input for this vote
+                bot_client.logger.info("nomination.stop reason=modifier_intercepted_after_announce nominee=%s", nominee_name)
                 return
 
         if (global_vars.game.show_tally):
@@ -279,6 +327,12 @@ class Day:
             await message_utils.safe_send(global_vars.channel, messageText)
 
         self.votes[-1].announcements.append(announcement.id)
+        bot_client.logger.info(
+            "nomination.vote_started nominee=%s vote_index=%s announcement_id=%s",
+            nominee_name,
+            len(self.votes) - 1,
+            announcement.id,
+        )
         await self.votes[-1].call_next()
 
     async def end(self):

--- a/model/game/day.py
+++ b/model/game/day.py
@@ -8,7 +8,14 @@ import global_vars
 import model.characters
 import model.game.whisper_mode
 import model.nomination_buttons
+import model.player
 from utils import message_utils, game_utils
+
+
+NOMINATION_DENIAL_RIOT_STORYTELLER_TURN = "riot_storyteller_turn"
+NOMINATION_DENIAL_MESSAGES = {
+    NOMINATION_DENIAL_RIOT_STORYTELLER_TURN: "Riot day is active. It is the storytellers' turn to nominate.",
+}
 
 
 class Day:
@@ -37,6 +44,7 @@ class Day:
     aboutToDie: tuple['model.player.Player | None', 'model.game.base_vote.BaseVote'] | None
     riot_active: bool
     st_riot_kill_override: bool
+    riot_storyteller_turn_active: bool
 
     def __init__(self):
         """Initialize a Day."""
@@ -50,6 +58,69 @@ class Day:
         self.aboutToDie = None
         self.riot_active = False
         self.st_riot_kill_override = False
+        self.riot_storyteller_turn_active = False
+
+    def is_eligible_riot_day(self) -> bool:
+        """Return True when Riot day enforcement is eligible (day 3+ with living, unpoisoned Riot)."""
+        if len(global_vars.game.days) < 3:
+            return False
+        return any(
+            player.character.role_name == "Riot"
+            and not player.character.is_poisoned
+            and not player.is_ghost
+            for player in global_vars.game.seatingOrder
+        )
+
+    def should_block_player_nomination_for_riot_storyteller_turn(self, nominator: model.player.Player | None) -> bool:
+        """Return True when Riot storyteller-turn latch is active and a non-storyteller player is nominating."""
+        if not self.riot_storyteller_turn_active or nominator is None:
+            return False
+        return nominator.alignment != model.player.STORYTELLER_ALIGNMENT
+
+    def nomination_denial_reason(self, nominator: model.player.Player | None) -> str | None:
+        """Return a domain reason code when a nomination must be denied, else None."""
+        if self.should_block_player_nomination_for_riot_storyteller_turn(nominator):
+            return NOMINATION_DENIAL_RIOT_STORYTELLER_TURN
+        return None
+
+    @staticmethod
+    def nomination_denial_message(reason: str) -> str:
+        """Map a nomination denial reason code to a user-facing message."""
+        return NOMINATION_DENIAL_MESSAGES.get(reason, "Nomination denied.")
+
+    async def latch_riot_storyteller_turn(self, source: str) -> None:
+        """Latch Riot storyteller-turn and send exactly one transition message."""
+        if not self.is_eligible_riot_day():
+            return
+        transitioned = not self.riot_storyteller_turn_active
+        self.riot_storyteller_turn_active = True
+        bot_client.logger.info(
+            "riot.storyteller_turn_set day=%s source=%s transitioned=%s",
+            len(global_vars.game.days),
+            source,
+            transitioned,
+        )
+        if transitioned:
+            msg = await message_utils.safe_send(
+                global_vars.channel,
+                "Riot day is active. It is the storytellers' turn to nominate.",
+            )
+            bot_client.logger.info(
+                "riot.storyteller_turn_prompt_sent source=%s message_id=%s",
+                source,
+                msg.id if msg else None,
+            )
+
+    def clear_riot_storyteller_turn(self, source: str) -> None:
+        """Clear Riot storyteller-turn latch when storytellers take their nomination turn."""
+        if not self.riot_storyteller_turn_active:
+            return
+        self.riot_storyteller_turn_active = False
+        bot_client.logger.info(
+            "riot.storyteller_turn_cleared day=%s source=%s",
+            len(global_vars.game.days),
+            source,
+        )
 
     async def open_pms(self):
         """Opens PMs."""
@@ -87,13 +158,26 @@ class Day:
 
         await game_utils.update_presence(bot_client.client)
 
-    async def nomination(self, nominee, nominator):
+    async def nomination(self, nominee, nominator) -> str | None:
         """Handle a nomination.
         
         Args:
             nominee: The player being nominated
             nominator: The player making the nomination
         """
+
+        denial_reason = self.nomination_denial_reason(nominator)
+        if denial_reason:
+            bot_client.logger.info(
+                "nomination.denied reason=%s nominee=%s nominator=%s",
+                denial_reason,
+                nominee.display_name if nominee else "storytellers",
+                nominator.display_name if nominator else "storytellers",
+            )
+            return denial_reason
+
+        if nominator is None:
+            self.clear_riot_storyteller_turn(source="day.nomination_storyteller_accepted")
 
         global_vars.game.whisper_mode = model.game.whisper_mode.WhisperMode.NEIGHBORS
         nominee_name = nominee.display_name if nominee else "storytellers"
@@ -334,6 +418,7 @@ class Day:
             announcement.id,
         )
         await self.votes[-1].call_next()
+        return None
 
     async def end(self):
         """Ends the day."""

--- a/model/game/day.py
+++ b/model/game/day.py
@@ -182,7 +182,7 @@ class Day:
         global_vars.game.whisper_mode = model.game.whisper_mode.WhisperMode.NEIGHBORS
         nominee_name = nominee.display_name if nominee else "storytellers"
         nominator_name = nominator.display_name if nominator else "storytellers"
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "nomination.start nominee=%s nominator=%s riot_active=%s votes_today=%s",
             nominee_name,
             nominator_name,
@@ -193,7 +193,7 @@ class Day:
 
         # todo: if organ grinder ability is active, then this first message should not be output.
         if not nominee:
-            bot_client.logger.info("nomination.branch storyteller_nominee")
+            bot_client.logger.debug("nomination.branch storyteller_nominee")
             self.votes.append(Vote(nominee, nominator))
             if self.aboutToDie is not None:
                 votes_needed = int(math.ceil((max(self.aboutToDie[1].votes + 1, self.votes[-1].majority))))
@@ -236,7 +236,7 @@ class Day:
             #  There may need to be some rework based on NominationModifier priority
             for person in global_vars.game.seatingOrder:
                 if isinstance(person.character, model.characters.NominationModifier) and proceed:
-                    bot_client.logger.info(
+                    bot_client.logger.debug(
                         "nomination.modifier_call modifier=%s nominee=%s nominator=%s",
                         person.character.role_name,
                         nominee_name,
@@ -245,17 +245,17 @@ class Day:
                     proceed = await person.character.on_nomination(
                         nominee, nominator, proceed
                     )
-                    bot_client.logger.info(
+                    bot_client.logger.debug(
                         "nomination.modifier_result modifier=%s proceed=%s",
                         person.character.role_name,
                         proceed,
                     )
             if not proceed:
                 # do not proceed with collecting votes
-                bot_client.logger.info("nomination.stop reason=modifier_intercepted nominee=%s", nominee_name)
+                bot_client.logger.debug("nomination.stop reason=modifier_intercepted nominee=%s", nominee_name)
                 return
         elif isinstance(nominee.character, model.characters.Traveler):
-            bot_client.logger.info("nomination.branch traveler_nominee nominee=%s", nominee_name)
+            bot_client.logger.debug("nomination.branch traveler_nominee nominee=%s", nominee_name)
             nominee.can_be_nominated = False
             self.votes.append(TravelerVote(nominee, nominator))
             announcement = await message_utils.safe_send(
@@ -278,7 +278,7 @@ class Day:
                 nominee_name, nominator_name, votes_needed, is_exile=True
             )
         else:
-            bot_client.logger.info("nomination.branch regular_nominee nominee=%s", nominee_name)
+            bot_client.logger.debug("nomination.branch regular_nominee nominee=%s", nominee_name)
             nominee.can_be_nominated = False
             self.votes.append(Vote(nominee, nominator))
             # FIXME:there might be a case where a player earlier in the seating order makes the nomination not proceed
@@ -287,7 +287,7 @@ class Day:
             proceed = True
             for person in global_vars.game.seatingOrder:
                 if isinstance(person.character, model.characters.NominationModifier) and proceed:
-                    bot_client.logger.info(
+                    bot_client.logger.debug(
                         "nomination.modifier_call modifier=%s nominee=%s nominator=%s",
                         person.character.role_name,
                         nominee_name,
@@ -296,14 +296,14 @@ class Day:
                     proceed = await person.character.on_nomination(
                         nominee, nominator, proceed
                     )
-                    bot_client.logger.info(
+                    bot_client.logger.debug(
                         "nomination.modifier_result modifier=%s proceed=%s",
                         person.character.role_name,
                         proceed,
                     )
             if not proceed:
                 # do not proceed with collecting votes
-                bot_client.logger.info("nomination.stop reason=modifier_intercepted nominee=%s", nominee_name)
+                bot_client.logger.debug("nomination.stop reason=modifier_intercepted nominee=%s", nominee_name)
                 return
             # Calculate votes needed based on whether there's already someone about to die
             if self.aboutToDie is not None:
@@ -353,7 +353,7 @@ class Day:
             #  There may need to be some rework based on NominationModifier priority
             for person in global_vars.game.seatingOrder:
                 if isinstance(person.character, model.characters.NominationModifier) and proceed:
-                    bot_client.logger.info(
+                    bot_client.logger.debug(
                         "nomination.modifier_call_post_announce modifier=%s nominee=%s nominator=%s",
                         person.character.role_name,
                         nominee_name,
@@ -362,14 +362,14 @@ class Day:
                     proceed = await person.character.on_nomination(
                         nominee, nominator, proceed
                     )
-                    bot_client.logger.info(
+                    bot_client.logger.debug(
                         "nomination.modifier_result_post_announce modifier=%s proceed=%s",
                         person.character.role_name,
                         proceed,
                     )
             if not proceed:
                 # do not proceed with collecting user input for this vote
-                bot_client.logger.info("nomination.stop reason=modifier_intercepted_after_announce nominee=%s", nominee_name)
+                bot_client.logger.debug("nomination.stop reason=modifier_intercepted_after_announce nominee=%s", nominee_name)
                 return
 
         if (global_vars.game.show_tally):
@@ -411,7 +411,7 @@ class Day:
             await message_utils.safe_send(global_vars.channel, messageText)
 
         self.votes[-1].announcements.append(announcement.id)
-        bot_client.logger.info(
+        bot_client.logger.debug(
             "nomination.vote_started nominee=%s vote_index=%s announcement_id=%s",
             nominee_name,
             len(self.votes) - 1,

--- a/tests/core/test_day_class.py
+++ b/tests/core/test_day_class.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import global_vars
-from model.game.day import Day
+from model.game.day import Day, NOMINATION_DENIAL_RIOT_STORYTELLER_TURN
 from model.game.vote import Vote
 from model.game.base_vote import VoteOutcome
 from model.game.whisper_mode import WhisperMode
@@ -294,6 +294,65 @@ async def test_nomination_with_fixture(mock_discord_setup, setup_test_game):
 
             # Restore the original close_noms method
             day.close_noms = original_close_noms
+
+
+@pytest.mark.asyncio
+async def test_nomination_denied_by_riot_storyteller_turn_has_no_side_effects(mock_discord_setup, setup_test_game):
+    """Day.nomination should return Riot storyteller-turn reason and avoid nomination side effects."""
+    day = Day()
+    day.riot_storyteller_turn_active = True
+    day.close_noms = AsyncMock()
+
+    global_vars.game = setup_test_game['game']
+    global_vars.game.days = [day]
+    global_vars.game.whisper_mode = WhisperMode.ALL
+    global_vars.game.show_tally = False
+    global_vars.game.seatingOrder = [setup_test_game['players']['alice'], setup_test_game['players']['bob']]
+
+    denial_reason = await day.nomination(setup_test_game['players']['bob'], setup_test_game['players']['alice'])
+
+    assert denial_reason == NOMINATION_DENIAL_RIOT_STORYTELLER_TURN
+    assert day.riot_storyteller_turn_active is True
+    assert day.votes == []
+    assert global_vars.game.whisper_mode == WhisperMode.ALL
+    day.close_noms.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_storyteller_nomination_allowed_and_clears_riot_storyteller_turn(mock_discord_setup, setup_test_game):
+    """Storyteller nominations should remain allowed and clear Riot storyteller-turn latch."""
+    day = Day()
+    day.riot_storyteller_turn_active = True
+    day.close_noms = AsyncMock()
+
+    global_vars.game = setup_test_game['game']
+    global_vars.game.days = [day]
+    global_vars.game.whisper_mode = WhisperMode.ALL
+    global_vars.game.show_tally = False
+    global_vars.game.seatingOrder = [setup_test_game['players']['alice'], setup_test_game['players']['bob']]
+    global_vars.player_role = mock_discord_setup['roles']['player']
+    global_vars.gamemaster_role = mock_discord_setup['roles']['gamemaster']
+    global_vars.gamemaster_role.members = [mock_discord_setup['members']['storyteller']]
+    global_vars.channel = mock_discord_setup['channels']['town_square']
+
+    mock_vote = MagicMock()
+    mock_vote.majority = 2
+    mock_vote.announcements = []
+    mock_vote.call_next = AsyncMock()
+
+    mock_announcement = MagicMock()
+    mock_announcement.id = 333
+    mock_announcement.pin = AsyncMock()
+
+    with patch('model.game.day.Vote', return_value=mock_vote), \
+         patch('utils.message_utils.safe_send', new_callable=AsyncMock, return_value=mock_announcement), \
+         patch('model.nomination_buttons.send_nomination_buttons_to_st_channels', new_callable=AsyncMock):
+        denial_reason = await day.nomination(setup_test_game['players']['alice'], None)
+
+    assert denial_reason is None
+    assert day.riot_storyteller_turn_active is False
+    day.close_noms.assert_awaited_once()
+    mock_vote.call_next.assert_awaited_once()
 
 
 class TestNominationThresholds:

--- a/tests/core/test_game_class.py
+++ b/tests/core/test_game_class.py
@@ -301,13 +301,7 @@ async def test_start_day_triggers_riot_day_3_reminder(mock_safe_send, _mock_upda
     mock_notify_storytellers.assert_awaited_once()
     assert reminder_text.isascii()
     assert "Riot is active on day 3!" in reminder_text
-    assert any(
-        call.args == (
-            mock_discord_setup['members']['storyteller'],
-            "Riot is active on day 3! Update all Minion characters to Riot sometime today if you have not already.",
-        )
-        for call in mock_safe_send.await_args_list
-    )
+    assert "minion" in reminder_text.lower()
     assert len(game.days) == 3
 
 

--- a/tests/core/test_game_class.py
+++ b/tests/core/test_game_class.py
@@ -2,7 +2,7 @@
 Tests for the Game class in bot_impl.py
 """
 
-from unittest.mock import AsyncMock, patch, Mock
+from unittest.mock import AsyncMock, MagicMock, patch, Mock
 
 import discord.errors
 import pytest
@@ -10,6 +10,7 @@ import pytest
 import global_vars
 from model import Game, Player
 from model.characters import Character
+from model.characters.specific import Riot
 from model.game import Day
 from tests.fixtures.discord_mocks import mock_discord_setup, MockChannel
 from tests.fixtures.game_fixtures import setup_test_game
@@ -239,6 +240,75 @@ async def test_start_day(mock_discord_setup, setup_test_game):
 
     # Verify day count increases
     assert len(game.days) == 2
+
+
+@pytest.mark.asyncio
+@patch('model.characters.specific.utils.notify_storytellers', new_callable=AsyncMock)
+@patch('model.game.game.game_utils.update_presence', new_callable=AsyncMock)
+@patch('model.game.game.message_utils.safe_send', new_callable=AsyncMock)
+async def test_start_day_triggers_riot_day_3_reminder(mock_safe_send, _mock_update_presence, mock_notify_storytellers,
+                                                       mock_discord_setup):
+    """Game.start_day should trigger Riot's day-3 storyteller reminder hook if minion exists."""
+    from model.characters.specific import Boomdandy
+
+    riot_player = Player(
+        Riot,
+        "evil",
+        mock_discord_setup['members']['charlie'],
+        mock_discord_setup['channels']['st_charlie'],
+        0,
+    )
+    minion_player = Player(
+        Boomdandy,
+        "evil",
+        mock_discord_setup['members']['bob'],
+        mock_discord_setup['channels']['st_bob'],
+        1,
+    )
+    storyteller = Player(
+        Character,
+        "good",
+        mock_discord_setup['members']['alice'],
+        mock_discord_setup['channels']['st_alice'],
+        2,
+    )
+
+    global_vars.channel = mock_discord_setup['channels']['town_square']
+    global_vars.player_role = mock_discord_setup['roles']['player']
+    global_vars.gamemaster_role = mock_discord_setup['roles']['gamemaster']
+    global_vars.gamemaster_role.members = [mock_discord_setup['members']['storyteller']]
+    global_vars.inactive_role = mock_discord_setup['roles']['inactive']
+    global_vars.whisper_channel = None
+
+    mock_sent_message = AsyncMock()
+    mock_sent_message.pin = AsyncMock()
+    mock_safe_send.return_value = mock_sent_message
+
+    game = Game(
+        seating_order=[riot_player, minion_player, storyteller],
+        seating_order_message=AsyncMock(),
+        info_channel_seating_order_message=AsyncMock(),
+        skip_storytellers=True,
+    )
+    game.days = [Day(), Day()]
+    game.storytellers = [mock_discord_setup['members']['storyteller']]
+    game.has_automated_life_and_death = True
+    global_vars.game = game
+
+    await game.start_day(kills=[], origin=MagicMock())
+
+    reminder_text = mock_notify_storytellers.await_args.args[0]
+    mock_notify_storytellers.assert_awaited_once()
+    assert reminder_text.isascii()
+    assert "Riot is active on day 3!" in reminder_text
+    assert any(
+        call.args == (
+            mock_discord_setup['members']['storyteller'],
+            "Riot is active on day 3! Update all Minion characters to Riot sometime today if you have not already.",
+        )
+        for call in mock_safe_send.await_args_list
+    )
+    assert len(game.days) == 3
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_game_class.py
+++ b/tests/core/test_game_class.py
@@ -243,10 +243,12 @@ async def test_start_day(mock_discord_setup, setup_test_game):
 
 
 @pytest.mark.asyncio
-@patch('model.characters.specific.utils.notify_storytellers', new_callable=AsyncMock)
+@patch('model.characters.specific.bot_client.logger.debug')
+@patch('model.characters.specific.utils.safe_send', new_callable=AsyncMock)
 @patch('model.game.game.game_utils.update_presence', new_callable=AsyncMock)
 @patch('model.game.game.message_utils.safe_send', new_callable=AsyncMock)
-async def test_start_day_triggers_riot_day_3_reminder(mock_safe_send, _mock_update_presence, mock_notify_storytellers,
+async def test_start_day_triggers_riot_day_3_reminder(mock_game_safe_send, _mock_update_presence,
+                                                       mock_riot_safe_send, mock_logger_debug,
                                                        mock_discord_setup):
     """Game.start_day should trigger Riot's day-3 storyteller reminder hook if minion exists."""
     from model.characters.specific import Boomdandy
@@ -282,7 +284,9 @@ async def test_start_day_triggers_riot_day_3_reminder(mock_safe_send, _mock_upda
 
     mock_sent_message = AsyncMock()
     mock_sent_message.pin = AsyncMock()
-    mock_safe_send.return_value = mock_sent_message
+    mock_game_safe_send.return_value = mock_sent_message
+
+    Riot._get_notification_state(0)
 
     game = Game(
         seating_order=[riot_player, minion_player, storyteller],
@@ -295,14 +299,24 @@ async def test_start_day_triggers_riot_day_3_reminder(mock_safe_send, _mock_upda
     game.has_automated_life_and_death = True
     global_vars.game = game
 
-    await game.start_day(kills=[], origin=MagicMock())
+    origin = MagicMock()
+    await game.start_day(kills=[], origin=origin)
 
-    reminder_text = mock_notify_storytellers.await_args.args[0]
-    mock_notify_storytellers.assert_awaited_once()
+    mock_riot_safe_send.assert_awaited_once()
+    reminder_text = mock_riot_safe_send.await_args.args[1]
     assert reminder_text.isascii()
     assert "Riot is active on day 3!" in reminder_text
-    assert "minion" in reminder_text.lower()
+    assert "update all minion characters to Riot" in reminder_text
+    assert any(
+        "riot.day_start decision=notify_storytellers" in call.args[0]
+        for call in mock_logger_debug.call_args_list
+    )
     assert len(game.days) == 3
+
+    game.days = [Day(), Day()]
+    await riot_player.character.on_day_start(origin=origin, kills=[])
+    assert mock_riot_safe_send.await_count == 1
+
 
 
 @pytest.mark.asyncio

--- a/tests/discord/test_on_message.py
+++ b/tests/discord/test_on_message.py
@@ -481,6 +481,70 @@ async def test_command_parser_handles_nominate(mock_discord_setup):
 
 
 @pytest.mark.asyncio
+async def test_nominate_command_riot_active_blocks_non_current_riot_nominee(mock_discord_setup, setup_test_game):
+    """When Riot is active, only the current riot nominee may nominate."""
+    global_vars.game = setup_test_game['game']
+    global_vars.channel = mock_discord_setup['channels']['town_square']
+
+    setup_test_game['game'].isDay = True
+    setup_test_game['game'].days[-1].isNoms = True
+    setup_test_game['game'].days[-1].riot_active = True
+    setup_test_game['players']['alice'].riot_nominee = False
+
+    alice_dm_channel = MockChannel(451, "dm-alice")
+    alice_dm_channel.guild = None
+    alice_message = MockMessage(
+        id=451,
+        content="@nominate charlie",
+        channel=alice_dm_channel,
+        author=mock_discord_setup['members']['alice'],
+        guild=None,
+    )
+
+    with patch('utils.game_utils.backup', return_value=None), \
+         patch('utils.player_utils.select_player', return_value=setup_test_game['players']['charlie']), \
+         patch('utils.message_utils.safe_send', new_callable=AsyncMock) as mock_safe_send:
+        await on_message(alice_message)
+
+    mock_safe_send.assert_called_with(
+        mock_discord_setup['members']['alice'],
+        "Riot is active, you may not nominate.",
+    )
+    setup_test_game['game'].days[-1].nomination.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_nominate_command_atheist_storyteller_nominee_unchanged(mock_discord_setup, setup_test_game):
+    """Atheist storyteller-nominee nomination path should still call Day.nomination(None, nominator)."""
+    global_vars.game = setup_test_game['game']
+    global_vars.channel = mock_discord_setup['channels']['town_square']
+
+    setup_test_game['game'].isDay = True
+    setup_test_game['game'].is_atheist = True
+    setup_test_game['game'].days[-1].isNoms = True
+    setup_test_game['game'].days[-1].votes = []
+
+    alice_dm_channel = MockChannel(452, "dm-alice")
+    alice_dm_channel.guild = None
+    alice_message = MockMessage(
+        id=452,
+        content="@nominate storytellers",
+        channel=alice_dm_channel,
+        author=mock_discord_setup['members']['alice'],
+        guild=None,
+    )
+
+    with patch('utils.game_utils.backup', return_value=None), \
+         patch('utils.message_utils.safe_send', new_callable=AsyncMock):
+        await on_message(alice_message)
+
+    setup_test_game['game'].days[-1].nomination.assert_awaited_once_with(
+        None,
+        setup_test_game['players']['alice'],
+    )
+
+
+@pytest.mark.asyncio
 async def test_openpms_command_from_storyteller(mock_discord_setup, setup_test_game):
     """Test openpms command from a storyteller."""
     # Set up global variables for this test

--- a/tests/discord/test_on_message.py
+++ b/tests/discord/test_on_message.py
@@ -10,7 +10,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 import pytest
 
 import global_vars
-from bot_impl import on_message
+from bot_impl import on_message, on_message_edit
 from model.game import WhisperMode
 # Import test fixtures from shared fixtures
 from tests.fixtures.discord_mocks import (
@@ -509,6 +509,76 @@ async def test_nominate_command_riot_active_blocks_non_current_riot_nominee(mock
     mock_safe_send.assert_called_with(
         mock_discord_setup['members']['alice'],
         "Riot is active, you may not nominate.",
+    )
+    setup_test_game['game'].days[-1].nomination.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_nominate_command_riot_storyteller_turn_blocks_player(mock_discord_setup, setup_test_game):
+    """When Riot storyteller-turn is latched, player command nominations are denied."""
+    global_vars.game = setup_test_game['game']
+    global_vars.channel = mock_discord_setup['channels']['town_square']
+
+    setup_test_game['game'].isDay = True
+    setup_test_game['game'].days[-1].isNoms = True
+    setup_test_game['game'].days[-1].riot_storyteller_turn_active = True
+
+    alice_dm_channel = MockChannel(453, "dm-alice")
+    alice_dm_channel.guild = None
+    alice_message = MockMessage(
+        id=453,
+        content="@nominate charlie",
+        channel=alice_dm_channel,
+        author=mock_discord_setup['members']['alice'],
+        guild=None,
+    )
+
+    with patch('utils.game_utils.backup', return_value=None), \
+         patch('utils.player_utils.select_player', return_value=setup_test_game['players']['charlie']), \
+         patch('utils.message_utils.safe_send', new_callable=AsyncMock) as mock_safe_send:
+        await on_message(alice_message)
+
+    mock_safe_send.assert_called_with(
+        mock_discord_setup['members']['alice'],
+        "Riot day is active. It is the storytellers' turn to nominate.",
+    )
+    setup_test_game['game'].days[-1].nomination.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pin_nominate_riot_storyteller_turn_blocks_player(mock_discord_setup, setup_test_game):
+    """When Riot storyteller-turn is latched, pinned nominations are denied."""
+    global_vars.game = setup_test_game['game']
+    global_vars.channel = mock_discord_setup['channels']['town_square']
+
+    setup_test_game['game'].isDay = True
+    setup_test_game['game'].days[-1].isNoms = True
+    setup_test_game['game'].days[-1].riot_storyteller_turn_active = True
+
+    before = MockMessage(
+        id=454,
+        content="nominate charlie",
+        channel=mock_discord_setup['channels']['town_square'],
+        author=mock_discord_setup['members']['alice'],
+        guild=mock_discord_setup['guild'],
+    )
+    before.pinned = False
+
+    after = MockMessage(
+        id=454,
+        content="nominate charlie",
+        channel=mock_discord_setup['channels']['town_square'],
+        author=mock_discord_setup['members']['alice'],
+        guild=mock_discord_setup['guild'],
+    )
+    after.pinned = True
+
+    with patch('utils.message_utils.safe_send', new_callable=AsyncMock) as mock_safe_send:
+        await on_message_edit(before, after)
+
+    mock_safe_send.assert_called_with(
+        mock_discord_setup['channels']['town_square'],
+        "Riot day is active. It is the storytellers' turn to nominate.",
     )
     setup_test_game['game'].days[-1].nomination.assert_not_called()
 

--- a/tests/game/test_character_functionality.py
+++ b/tests/game/test_character_functionality.py
@@ -225,15 +225,16 @@ async def test_storyteller_abilities(setup_character_test):
 
 
 @pytest.mark.asyncio
-@patch('model.characters.specific.utils.notify_storytellers', new_callable=AsyncMock)
-@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
-async def test_riot_day_3_reminder_sent_on_day_start_once(mock_safe_send, mock_notify_storytellers):
+@patch('model.characters.specific.bot_client.logger.debug')
+@patch('model.characters.specific.utils.safe_send', new_callable=AsyncMock)
+async def test_riot_day_3_reminder_sent_on_day_start_once(mock_safe_send, mock_logger_debug):
     """Riot should notify storytellers at start of day 3, once, if a minion exists."""
     from model.characters.specific import Boomdandy
 
     riot_parent = MagicMock()
     riot_parent.is_ghost = False
     riot = Riot(riot_parent)
+    Riot._get_notification_state(0)
 
     # Create a minion player
     minion_player = MagicMock()
@@ -252,25 +253,28 @@ async def test_riot_day_3_reminder_sent_on_day_start_once(mock_safe_send, mock_n
 
     await riot.on_day_start(origin=MagicMock(), kills=[])
 
-    storyteller_reminder = mock_notify_storytellers.await_args.args[0]
-    assert riot.day_3_notification_sent is True
-    mock_notify_storytellers.assert_awaited_once()
-    assert "Riot is active on day 3!" in storyteller_reminder
-    assert "minion" in storyteller_reminder.lower()
-    assert storyteller_reminder.isascii()
+    assert Riot._get_notification_state(3)["minion"] is True
+    assert any(
+        "riot.day_start decision=notify_storytellers" in call.args[0]
+        for call in mock_logger_debug.call_args_list
+    )
 
     await riot.on_day_start(origin=MagicMock(), kills=[])
-    mock_notify_storytellers.assert_awaited_once()
+    assert sum(
+        "riot.day_start decision=notify_storytellers" in call.args[0]
+        for call in mock_logger_debug.call_args_list
+    ) == 1
 
 
 @pytest.mark.asyncio
-@patch('model.characters.specific.utils.notify_storytellers', new_callable=AsyncMock)
-@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
-async def test_riot_day_3_reminder_not_sent_without_minion(mock_safe_send, mock_notify_storytellers):
+@patch('model.characters.specific.bot_client.logger.debug')
+@patch('model.characters.specific.utils.safe_send', new_callable=AsyncMock)
+async def test_riot_day_3_reminder_not_sent_without_minion(mock_safe_send, mock_logger_debug):
     """Riot should NOT notify storytellers if no minion exists in the game."""
     riot_parent = MagicMock()
     riot_parent.is_ghost = False
     riot = Riot(riot_parent)
+    Riot._get_notification_state(0)
 
     global_vars.game = MagicMock()
     global_vars.game.has_automated_life_and_death = True
@@ -284,8 +288,11 @@ async def test_riot_day_3_reminder_not_sent_without_minion(mock_safe_send, mock_
     await riot.on_day_start(origin=MagicMock(), kills=[])
 
     # Notification should NOT be sent
-    assert riot.day_3_notification_sent is False
-    mock_notify_storytellers.assert_not_awaited()
+    assert Riot._get_notification_state(3)["minion"] is False
+    assert not any(
+        "riot.day_start decision=notify_storytellers" in call.args[0]
+        for call in mock_logger_debug.call_args_list
+    )
     mock_safe_send.assert_not_awaited()
 
 

--- a/tests/game/test_character_functionality.py
+++ b/tests/game/test_character_functionality.py
@@ -251,19 +251,13 @@ async def test_riot_day_3_reminder_sent_on_day_start_once(mock_safe_send, mock_n
     await riot.on_day_start(origin=MagicMock(), kills=[])
 
     storyteller_reminder = mock_notify_storytellers.await_args.args[0]
-    reminder = "Riot is active on day 3! Update all Minion characters to Riot sometime today if you have not already."
-
     assert riot.day_3_notification_sent is True
     mock_notify_storytellers.assert_awaited_once()
     assert "Riot is active on day 3!" in storyteller_reminder
-    assert "Please update all minion characters to Riot at the appropriate time." in storyteller_reminder
-    assert mock_safe_send.await_count == 2
-    mock_safe_send.assert_any_await(st1, reminder)
-    mock_safe_send.assert_any_await(st2, reminder)
-    assert all(call.args[1].isascii() for call in mock_safe_send.await_args_list)
+    assert "minion" in storyteller_reminder.lower()
+    assert storyteller_reminder.isascii()
 
     await riot.on_day_start(origin=MagicMock(), kills=[])
-    assert mock_safe_send.await_count == 2
     mock_notify_storytellers.assert_awaited_once()
 
 

--- a/tests/game/test_character_functionality.py
+++ b/tests/game/test_character_functionality.py
@@ -9,9 +9,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import pytest_asyncio
 
+import global_vars
 from model.characters.base import Character, VoteModifier, NominationModifier, DeathModifier, Storyteller, Demon
 from model.characters.registry import CHARACTER_REGISTRY
-from model.characters.specific import Washerwoman, FortuneTeller
+from model.characters.specific import Washerwoman, FortuneTeller, Riot
 from model.player import Player, STORYTELLER_ALIGNMENT
 from tests.fixtures.discord_mocks import MockMember, MockChannel
 
@@ -219,3 +220,150 @@ async def test_storyteller_abilities(setup_character_test):
 
         # Verify the message was sent
         mock_message.assert_called_once_with(washerwoman, "This is a secret message.")
+
+
+@pytest.mark.asyncio
+@patch('model.characters.specific.utils.notify_storytellers', new_callable=AsyncMock)
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_day_3_reminder_sent_on_day_start_once(mock_safe_send, mock_notify_storytellers):
+    """Riot should notify storytellers at start of day 3, once, if a minion exists."""
+    from model.characters.specific import Boomdandy
+
+    riot_parent = MagicMock()
+    riot_parent.is_ghost = False
+    riot = Riot(riot_parent)
+
+    # Create a minion player
+    minion_player = MagicMock()
+    minion_char = Boomdandy(minion_player)
+    minion_player.character = minion_char
+
+    global_vars.game = MagicMock()
+    global_vars.game.has_automated_life_and_death = True
+    global_vars.game.days = [MagicMock(), MagicMock()]  # about to start day 3
+    global_vars.game.seatingOrder = [minion_player]
+
+    st1 = MagicMock()
+    st2 = MagicMock()
+    global_vars.gamemaster_role = MagicMock()
+    global_vars.gamemaster_role.members = [st1, st2]
+
+    await riot.on_day_start(origin=MagicMock(), kills=[])
+
+    storyteller_reminder = mock_notify_storytellers.await_args.args[0]
+    reminder = "Riot is active on day 3! Update all Minion characters to Riot sometime today if you have not already."
+
+    assert riot.day_3_notification_sent is True
+    mock_notify_storytellers.assert_awaited_once()
+    assert "Riot is active on day 3!" in storyteller_reminder
+    assert "Please update all minion characters to Riot at the appropriate time." in storyteller_reminder
+    assert mock_safe_send.await_count == 2
+    mock_safe_send.assert_any_await(st1, reminder)
+    mock_safe_send.assert_any_await(st2, reminder)
+    assert all(call.args[1].isascii() for call in mock_safe_send.await_args_list)
+
+    await riot.on_day_start(origin=MagicMock(), kills=[])
+    assert mock_safe_send.await_count == 2
+    mock_notify_storytellers.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch('model.characters.specific.utils.notify_storytellers', new_callable=AsyncMock)
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_day_3_reminder_not_sent_without_minion(mock_safe_send, mock_notify_storytellers):
+    """Riot should NOT notify storytellers if no minion exists in the game."""
+    riot_parent = MagicMock()
+    riot_parent.is_ghost = False
+    riot = Riot(riot_parent)
+
+    global_vars.game = MagicMock()
+    global_vars.game.has_automated_life_and_death = True
+    global_vars.game.days = [MagicMock(), MagicMock()]  # about to start day 3
+    global_vars.game.seatingOrder = []  # No minions
+
+    st1 = MagicMock()
+    global_vars.gamemaster_role = MagicMock()
+    global_vars.gamemaster_role.members = [st1]
+
+    await riot.on_day_start(origin=MagicMock(), kills=[])
+
+    # Notification should NOT be sent
+    assert riot.day_3_notification_sent is False
+    mock_notify_storytellers.assert_not_awaited()
+    mock_safe_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch('utils.character_utils.has_ability', return_value=False)
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_nomination_no_longer_sends_day_3_reminder(mock_safe_send, _mock_has_ability):
+    """Riot nomination chain should proceed without sending day-3 reminder text."""
+    riot_parent = MagicMock()
+    riot_parent.is_ghost = False
+    riot = Riot(riot_parent)
+
+    vote = MagicMock()
+    vote.announcements = []
+    this_day = MagicMock()
+    this_day.votes = [vote]
+    this_day.riot_active = False
+    this_day.st_riot_kill_override = False
+    this_day.open_noms = AsyncMock()
+
+    global_vars.game = MagicMock()
+    global_vars.game.has_automated_life_and_death = True
+    global_vars.game.show_tally = False
+    global_vars.game.days = [MagicMock(), MagicMock(), this_day]
+    global_vars.game.seatingOrder = []
+
+    global_vars.player_role = MagicMock()
+    global_vars.player_role.mention = "@players"
+    global_vars.channel = MagicMock()
+
+    global_vars.gamemaster_role = MagicMock()
+    global_vars.gamemaster_role.members = [MagicMock()]
+
+    announcement_message = MagicMock()
+    announcement_message.id = 100
+    announcement_message.pin = AsyncMock()
+    riot_message = MagicMock()
+    riot_message.id = 101
+    riot_message.pin = AsyncMock()
+    mock_safe_send.side_effect = [announcement_message, riot_message]
+
+    nominee = MagicMock()
+    nominee.display_name = "Nominee"
+    nominee.user.mention = "@nominee"
+    nominee.character.is_poisoned = False
+    nominee.kill = AsyncMock()
+    nominee.riot_nominee = False
+    nominee.can_nominate = False
+
+    nominator = MagicMock()
+    nominator.display_name = "Nominator"
+    nominator.character.is_poisoned = False
+    nominator.is_ghost = False
+    nominator.riot_nominee = True
+
+    result = await riot.on_nomination(nominee, nominator, True)
+
+    reminder = "Riot is active on day 3! Please manually update all Minion characters to Riot."
+    sent_texts = [call.args[1] for call in mock_safe_send.await_args_list if len(call.args) > 1]
+
+    assert result is False
+    assert riot.day_3_notification_sent is False
+    assert reminder not in sent_texts
+    assert sent_texts == [
+        "@players, @nominee has been nominated by Nominator.",
+        "Riot is in play. @nominee to nominate",
+    ]
+    assert all(text.isascii() for text in sent_texts)
+    announcement_message.pin.assert_awaited_once()
+    assert vote.announcements == [100]
+    assert this_day.riot_active is True
+    nominee.kill.assert_awaited_once()
+    assert nominator.riot_nominee is False
+    assert nominee.riot_nominee is True
+    assert nominee.can_nominate is True
+    this_day.open_noms.assert_awaited_once()
+

--- a/tests/game/test_character_functionality.py
+++ b/tests/game/test_character_functionality.py
@@ -310,7 +310,10 @@ async def test_riot_nomination_player_day3_with_eligible_riot_intercepts(mock_sa
     global_vars.game.has_automated_life_and_death = True
     global_vars.game.show_tally = False
     global_vars.game.days = [MagicMock(), MagicMock(), this_day]
-    global_vars.game.seatingOrder = [riot_parent]
+    other_player = MagicMock()
+    other_player.is_ghost = False
+    other_player.character.role_name = "Townsfolk"
+    global_vars.game.seatingOrder = [riot_parent, other_player, MagicMock(is_ghost=False), MagicMock(is_ghost=False)]
 
     global_vars.player_role = MagicMock()
     global_vars.player_role.mention = "@players"
@@ -361,6 +364,137 @@ async def test_riot_nomination_player_day3_with_eligible_riot_intercepts(mock_sa
 
 @pytest.mark.asyncio
 @patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_nomination_player_day3_stops_when_living_players_le_two(mock_safe_send):
+    """Riot should end the chain when a storyteller override kill leaves two or fewer living players."""
+    riot_parent = MagicMock()
+    riot_parent.is_ghost = False
+    riot = Riot(riot_parent)
+    riot_parent.character = riot
+
+    this_day = MagicMock()
+    this_day.votes = [MagicMock(announcements=[])]
+    this_day.riot_active = False
+    this_day.st_riot_kill_override = True
+    this_day.open_noms = AsyncMock()
+
+    global_vars.game = MagicMock()
+    global_vars.game.has_automated_life_and_death = True
+    global_vars.game.show_tally = False
+    global_vars.game.days = [MagicMock(), MagicMock(), this_day]
+
+    class Nominee:
+        def __init__(self):
+            self.display_name = "Nominee"
+            self.user = MagicMock()
+            self.user.mention = "@nominee"
+            self.is_ghost = False
+            self.character = MagicMock()
+            self.character.role_name = "Townsfolk"
+            self.character.is_poisoned = False
+            self.riot_nominee = False
+            self.can_nominate = False
+
+        async def kill(self):
+            self.is_ghost = True
+            return True
+
+    nominee = Nominee()
+
+    other_player = MagicMock()
+    other_player.is_ghost = False
+    other_player.character.role_name = "Townsfolk"
+
+    global_vars.game.seatingOrder = [riot_parent, other_player, nominee]
+
+    global_vars.player_role = MagicMock()
+    global_vars.player_role.mention = "@players"
+    global_vars.channel = MagicMock()
+
+    announcement_message = MagicMock()
+    announcement_message.id = 200
+    announcement_message.pin = AsyncMock()
+    mock_safe_send.side_effect = [announcement_message, MagicMock()]
+
+    result = await riot.on_nomination(nominee, None, True)
+
+    assert result is False
+    assert [call.args[1] for call in mock_safe_send.await_args_list if len(call.args) > 1] == [
+        "@players, @nominee has been nominated by the storytellers.",
+        "The game is over! Please wait for the storytellers to conclude the game.",
+    ]
+    this_day.open_noms.assert_not_awaited()
+    assert nominee.is_ghost is True
+    assert nominee.riot_nominee is False
+    assert nominee.can_nominate is False
+
+
+@pytest.mark.asyncio
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_nomination_player_day3_continues_when_living_players_gt_two(mock_safe_send):
+    """Riot should continue the chain when more than two living players remain."""
+    riot_parent = MagicMock()
+    riot_parent.is_ghost = False
+    riot = Riot(riot_parent)
+    riot_parent.character = riot
+
+    this_day = MagicMock()
+    this_day.votes = [MagicMock(announcements=[])]
+    this_day.riot_active = False
+    this_day.st_riot_kill_override = False
+    this_day.open_noms = AsyncMock()
+
+    global_vars.game = MagicMock()
+    global_vars.game.has_automated_life_and_death = True
+    global_vars.game.show_tally = False
+    global_vars.game.days = [MagicMock(), MagicMock(), this_day]
+
+    nominee = MagicMock()
+    nominee.display_name = "Nominee"
+    nominee.user.mention = "@nominee"
+    nominee.is_ghost = False
+    nominee.kill = AsyncMock(side_effect=lambda: setattr(nominee, 'is_ghost', True))
+    nominee.riot_nominee = False
+    nominee.can_nominate = False
+
+    other_players = []
+    for _ in range(2):
+        player = MagicMock()
+        player.is_ghost = False
+        player.character.role_name = "Townsfolk"
+        other_players.append(player)
+
+    global_vars.game.seatingOrder = [riot_parent, *other_players, nominee]
+
+    global_vars.player_role = MagicMock()
+    global_vars.player_role.mention = "@players"
+    global_vars.channel = MagicMock()
+
+    announcement_message = MagicMock()
+    announcement_message.id = 300
+    announcement_message.pin = AsyncMock()
+    riot_message = MagicMock()
+    riot_message.id = 301
+    mock_safe_send.side_effect = [announcement_message, riot_message]
+
+    nominator = MagicMock()
+    nominator.display_name = "Nominator"
+    nominator.riot_nominee = True
+
+    result = await riot.on_nomination(nominee, nominator, True)
+
+    assert result is False
+    assert [call.args[1] for call in mock_safe_send.await_args_list if len(call.args) > 1] == [
+        "@players, @nominee has been nominated by Nominator.",
+        "Riot is in play. @nominee to nominate",
+    ]
+    nominee.kill.assert_awaited_once()
+    this_day.open_noms.assert_awaited_once()
+    assert nominee.riot_nominee is True
+    assert nominee.can_nominate is True
+
+
+@pytest.mark.asyncio
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
 async def test_riot_nomination_storyteller_day3_with_eligible_riot_intercepts(mock_safe_send):
     """Day 3+ storyteller-initiated nomination should enter Riot chain when an eligible Riot exists."""
     riot_parent = MagicMock()
@@ -380,7 +514,13 @@ async def test_riot_nomination_storyteller_day3_with_eligible_riot_intercepts(mo
     global_vars.game.has_automated_life_and_death = True
     global_vars.game.show_tally = False
     global_vars.game.days = [MagicMock(), MagicMock(), this_day]
-    global_vars.game.seatingOrder = [riot_parent]
+    other_players = []
+    for _ in range(2):
+        player = MagicMock()
+        player.is_ghost = False
+        player.character.role_name = "Townsfolk"
+        other_players.append(player)
+    global_vars.game.seatingOrder = [riot_parent, *other_players, MagicMock(is_ghost=False)]
 
     global_vars.player_role = MagicMock()
     global_vars.player_role.mention = "@players"

--- a/tests/game/test_character_functionality.py
+++ b/tests/game/test_character_functionality.py
@@ -288,13 +288,13 @@ async def test_riot_day_3_reminder_not_sent_without_minion(mock_safe_send, mock_
 
 
 @pytest.mark.asyncio
-@patch('utils.character_utils.has_ability', return_value=False)
 @patch('utils.message_utils.safe_send', new_callable=AsyncMock)
-async def test_riot_nomination_no_longer_sends_day_3_reminder(mock_safe_send, _mock_has_ability):
-    """Riot nomination chain should proceed without sending day-3 reminder text."""
+async def test_riot_nomination_player_day3_with_eligible_riot_intercepts(mock_safe_send):
+    """Day 3+ player nomination should still activate Riot chain when an eligible Riot exists."""
     riot_parent = MagicMock()
     riot_parent.is_ghost = False
     riot = Riot(riot_parent)
+    riot_parent.character = riot
 
     vote = MagicMock()
     vote.announcements = []
@@ -308,7 +308,7 @@ async def test_riot_nomination_no_longer_sends_day_3_reminder(mock_safe_send, _m
     global_vars.game.has_automated_life_and_death = True
     global_vars.game.show_tally = False
     global_vars.game.days = [MagicMock(), MagicMock(), this_day]
-    global_vars.game.seatingOrder = []
+    global_vars.game.seatingOrder = [riot_parent]
 
     global_vars.player_role = MagicMock()
     global_vars.player_role.mention = "@players"
@@ -335,18 +335,13 @@ async def test_riot_nomination_no_longer_sends_day_3_reminder(mock_safe_send, _m
 
     nominator = MagicMock()
     nominator.display_name = "Nominator"
-    nominator.character.is_poisoned = False
-    nominator.is_ghost = False
     nominator.riot_nominee = True
 
     result = await riot.on_nomination(nominee, nominator, True)
 
-    reminder = "Riot is active on day 3! Please manually update all Minion characters to Riot."
     sent_texts = [call.args[1] for call in mock_safe_send.await_args_list if len(call.args) > 1]
 
     assert result is False
-    assert riot.day_3_notification_sent is False
-    assert reminder not in sent_texts
     assert sent_texts == [
         "@players, @nominee has been nominated by Nominator.",
         "Riot is in play. @nominee to nominate",
@@ -360,4 +355,155 @@ async def test_riot_nomination_no_longer_sends_day_3_reminder(mock_safe_send, _m
     assert nominee.riot_nominee is True
     assert nominee.can_nominate is True
     this_day.open_noms.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_nomination_storyteller_day3_with_eligible_riot_intercepts(mock_safe_send):
+    """Day 3+ storyteller-initiated nomination should enter Riot chain when an eligible Riot exists."""
+    riot_parent = MagicMock()
+    riot_parent.is_ghost = False
+    riot = Riot(riot_parent)
+    riot_parent.character = riot
+
+    vote = MagicMock()
+    vote.announcements = []
+    this_day = MagicMock()
+    this_day.votes = [vote]
+    this_day.riot_active = False
+    this_day.st_riot_kill_override = True
+    this_day.open_noms = AsyncMock()
+
+    global_vars.game = MagicMock()
+    global_vars.game.has_automated_life_and_death = True
+    global_vars.game.show_tally = False
+    global_vars.game.days = [MagicMock(), MagicMock(), this_day]
+    global_vars.game.seatingOrder = [riot_parent]
+
+    global_vars.player_role = MagicMock()
+    global_vars.player_role.mention = "@players"
+    global_vars.channel = MagicMock()
+
+    announcement_message = MagicMock()
+    announcement_message.id = 100
+    announcement_message.pin = AsyncMock()
+    riot_message = MagicMock()
+    riot_message.id = 101
+    mock_safe_send.side_effect = [announcement_message, riot_message]
+
+    nominee = MagicMock()
+    nominee.display_name = "Nominee"
+    nominee.user.mention = "@nominee"
+    nominee.kill = AsyncMock()
+    nominee.riot_nominee = False
+    nominee.can_nominate = False
+
+    result = await riot.on_nomination(nominee, None, True)
+
+    assert result is False
+    assert this_day.riot_active is True
+    nominee.kill.assert_awaited_once()
+    assert vote.announcements == [100]
+    this_day.open_noms.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_nomination_storyteller_day3_with_no_eligible_riot_passes_through(mock_safe_send):
+    """Day 3+ storyteller-initiated nomination should pass through when no living unpoisoned Riot exists."""
+    riot_parent = MagicMock()
+    riot_parent.is_ghost = False
+    riot = Riot(riot_parent)
+    riot.poison()
+    riot_parent.character = riot
+
+    this_day = MagicMock()
+    this_day.votes = [MagicMock(announcements=[])]
+    this_day.riot_active = False
+    this_day.st_riot_kill_override = False
+    this_day.open_noms = AsyncMock()
+
+    global_vars.game = MagicMock()
+    global_vars.game.has_automated_life_and_death = True
+    global_vars.game.show_tally = False
+    global_vars.game.days = [MagicMock(), MagicMock(), this_day]
+    global_vars.game.seatingOrder = [riot_parent]
+
+    nominee = MagicMock()
+    nominee.display_name = "Nominee"
+    nominee.kill = AsyncMock()
+
+    result = await riot.on_nomination(nominee, None, True)
+
+    assert result is True
+    assert this_day.riot_active is False
+    nominee.kill.assert_not_called()
+    mock_safe_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_nomination_day2_passes_through(mock_safe_send):
+    """Day 1/2 nominations should remain pass-through even with an eligible Riot."""
+    riot_parent = MagicMock()
+    riot_parent.is_ghost = False
+    riot = Riot(riot_parent)
+    riot_parent.character = riot
+
+    this_day = MagicMock()
+    this_day.votes = [MagicMock(announcements=[])]
+    this_day.riot_active = False
+    this_day.st_riot_kill_override = False
+    this_day.open_noms = AsyncMock()
+
+    global_vars.game = MagicMock()
+    global_vars.game.has_automated_life_and_death = True
+    global_vars.game.show_tally = False
+    global_vars.game.days = [MagicMock(), this_day]
+    global_vars.game.seatingOrder = [riot_parent]
+
+    nominee = MagicMock()
+    nominee.display_name = "Nominee"
+    nominee.kill = AsyncMock()
+    nominator = MagicMock()
+    nominator.display_name = "Nominator"
+
+    result = await riot.on_nomination(nominee, nominator, True)
+
+    assert result is True
+    assert this_day.riot_active is False
+    nominee.kill.assert_not_called()
+    mock_safe_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_nomination_storyteller_nominee_passes_through(mock_safe_send):
+    """Storyteller nominee path (Atheist handling entrypoint) should remain pass-through."""
+    riot_parent = MagicMock()
+    riot_parent.is_ghost = False
+    riot = Riot(riot_parent)
+    riot_parent.character = riot
+
+    this_day = MagicMock()
+    this_day.votes = [MagicMock(announcements=[])]
+    this_day.riot_active = False
+    this_day.st_riot_kill_override = False
+    this_day.open_noms = AsyncMock()
+
+    global_vars.game = MagicMock()
+    global_vars.game.has_automated_life_and_death = True
+    global_vars.game.show_tally = False
+    global_vars.game.days = [MagicMock(), MagicMock(), this_day]
+    global_vars.game.seatingOrder = [riot_parent]
+
+    nominator = MagicMock()
+    nominator.display_name = "Nominator"
+
+    result = await riot.on_nomination(None, nominator, True)
+
+    assert result is True
+    assert this_day.riot_active is False
+    mock_safe_send.assert_not_awaited()
+
 

--- a/tests/game/test_character_functionality.py
+++ b/tests/game/test_character_functionality.py
@@ -13,6 +13,8 @@ import global_vars
 from model.characters.base import Character, VoteModifier, NominationModifier, DeathModifier, Storyteller, Demon
 from model.characters.registry import CHARACTER_REGISTRY
 from model.characters.specific import Washerwoman, FortuneTeller, Riot
+from model.game.day import Day
+from model.game.vote import Vote
 from model.player import Player, STORYTELLER_ALIGNMENT
 from tests.fixtures.discord_mocks import MockMember, MockChannel
 
@@ -505,5 +507,67 @@ async def test_riot_nomination_storyteller_nominee_passes_through(mock_safe_send
     assert result is True
     assert this_day.riot_active is False
     mock_safe_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_storyteller_turn_latches_in_vote_finalize_before_noms_reopen(mock_safe_send):
+    """Storyteller nominee vote finalization should latch Riot storyteller-turn and announce once."""
+    this_day = Day()
+    this_day.open_noms = AsyncMock()
+    this_day.open_pms = AsyncMock()
+
+    riot_player = MagicMock()
+    riot_player.character.role_name = "Riot"
+    riot_player.character.is_poisoned = False
+    riot_player.is_ghost = False
+
+    global_vars.game = MagicMock()
+    global_vars.game.days = [MagicMock(), MagicMock(), this_day]
+    global_vars.game.seatingOrder = [riot_player]
+    global_vars.channel = MagicMock()
+
+    prompt_message = MagicMock()
+    prompt_message.id = 555
+    mock_safe_send.return_value = prompt_message
+
+    vote = Vote(None, MagicMock())
+    await vote._finalize_vote()
+
+    assert this_day.riot_storyteller_turn_active is True
+    mock_safe_send.assert_awaited_once_with(
+        global_vars.channel,
+        "Riot day is active. It is the storytellers' turn to nominate.",
+    )
+    this_day.open_noms.assert_awaited_once()
+    this_day.open_pms.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch('utils.message_utils.safe_send', new_callable=AsyncMock)
+async def test_riot_storyteller_turn_prompt_sent_once_per_transition(mock_safe_send):
+    """Riot storyteller-turn prompt should send once per transition into active state."""
+    this_day = Day()
+
+    riot_player = MagicMock()
+    riot_player.character.role_name = "Riot"
+    riot_player.character.is_poisoned = False
+    riot_player.is_ghost = False
+
+    global_vars.game = MagicMock()
+    global_vars.game.days = [MagicMock(), MagicMock(), this_day]
+    global_vars.game.seatingOrder = [riot_player]
+    global_vars.channel = MagicMock()
+
+    msg = MagicMock()
+    msg.id = 556
+    mock_safe_send.return_value = msg
+
+    await this_day.latch_riot_storyteller_turn(source="test.first")
+    await this_day.latch_riot_storyteller_turn(source="test.repeat")
+    this_day.clear_riot_storyteller_turn(source="test.clear")
+    await this_day.latch_riot_storyteller_turn(source="test.second")
+
+    assert mock_safe_send.await_count == 2
 
 

--- a/utils/message_utils.py
+++ b/utils/message_utils.py
@@ -23,7 +23,7 @@ def _split_text(text: str, max_length: int = 2000) -> list[str]:
 
 
 async def safe_send(
-        channel: discord.abc.Messageable | discord.Member | discord.User,
+        channel: discord.abc.Messageable | discord.Member | discord.User | None,
         content: str | None = None,
     **kwargs
 ) -> discord.Message | None:
@@ -38,6 +38,10 @@ async def safe_send(
     Returns:
         The sent message or None if failed
     """
+    if channel is None:
+        # log issue
+        bot_client.logger.warning(f"The channel to send is None. message dropped: {content}")
+        return None
     try:
         # Handle empty content
         if not content and not any(k in kwargs for k in ['embed', 'embeds', 'file', 'files']):


### PR DESCRIPTION
This pull request introduces improved logging and consistent handling of nomination denial and submission logic for the "Riot" nomination command, as well as making the log level configurable via an environment variable. The changes enhance debuggability, standardize how nomination denials are communicated, and refactor repeated logic into helper functions.

**Logging Improvements and Configuration**
- Made the Discord bot's log level configurable via the `FIVEOFSWORDS_LOG_LEVEL` environment variable, defaulting to `INFO` in the Dockerfile and updating logger setup in `bot_client.py` to respect this setting. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R12-R13) [[2]](diffhunk://#diff-b3c7b95f887af3b16e255613351168cc9a3e544e44f80e7cffb63b33ae566c19R12-R17)
- Added detailed debug-level logging throughout the nomination command handling in `bot_impl.py`, capturing key events and denial reasons for easier troubleshooting. [[1]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R1829-R1836) [[2]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R1847-R1863) [[3]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R1893-R1912) [[4]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R1928-R1947) [[5]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R1957-R1969) [[6]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R2945-R2948) [[7]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R2959-R2963)

**Nomination Denial and Submission Refactoring**
- Introduced helper functions `_send_nomination_denial_if_needed` and `_submit_nomination_with_domain_result` in `bot_impl.py` to standardize and centralize how nomination denials and submissions are handled, reducing code duplication and ensuring consistent messaging.
- Updated all nomination and pin-nomination code paths to use these helpers, ensuring that denial messages are always sent in the same way and that logging occurs for all key outcomes. [[1]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R1893-R1912) [[2]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R1928-R1947) [[3]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312L1893-R1996) [[4]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312R2919-R2927) [[5]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312L2851-R2981) [[6]](diffhunk://#diff-20486d1de10260e1e3b317e93bc14c365267251dc8c11a04fdae0ea9f0d1b312L2868-R3012)

**Minor Code Improvements**
- Added a missing import for `has_ability` in `model/characters/specific.py`.